### PR TITLE
Add unit tests for SimulationService and SimulationStepModel synchron…

### DIFF
--- a/Testing/UnitTests/Services/SimulationServiceRunTests.cs
+++ b/Testing/UnitTests/Services/SimulationServiceRunTests.cs
@@ -19,7 +19,7 @@ public class SimulationServiceRunTests
     {
         var sut = BuildSut();
 
-        var result = await sut.RunAsync("bubble_sort", [5, 1, 4, 2]);
+        var result = await sut.RunAsync("bubble_sort", [5, 1, 4, 2], null);
 
         result.AlgorithmName.Should().Be("Bubble Sort");
         result.TotalSteps.Should().Be(result.Steps.Count);
@@ -38,7 +38,7 @@ public class SimulationServiceRunTests
     {
         var sut = BuildSut();
 
-        var act = () => sut.RunAsync("unknown_algorithm", [3, 2, 1]);
+        var act = () => sut.RunAsync("unknown_algorithm", [3, 2, 1], null);
 
         await act.Should()
             .ThrowAsync<NotSupportedException>()

--- a/Testing/UnitTests/Services/Simulations/SimulationSynchronizationTests.cs
+++ b/Testing/UnitTests/Services/Simulations/SimulationSynchronizationTests.cs
@@ -1,0 +1,62 @@
+using backend.Services.Simulations;
+using FluentAssertions;
+using Xunit;
+
+namespace backend.Tests.Services.Simulations;
+
+public class SimulationSynchronizationTests
+{
+    [Fact(DisplayName = "UT-SYNC-01 — SimulationStepModel: line_number is present and non-zero on every step")]
+    public void StepGenerators_ShouldAlwaysPopulateNonZeroLineNumber()
+    {
+        var bubble = new BubbleSortSimulationEngine();
+        var binary = new BinarySearchSimulationEngine();
+
+        var bubbleSteps = bubble.Run([5, 1, 4, 2]).Steps;
+        var binaryFoundSteps = binary.Run([3, 7, 12, 19], targetValue: 12).Steps;
+        var binaryNotFoundSteps = binary.Run([3, 7, 12, 19], targetValue: 100).Steps;
+        var binaryEmptySteps = binary.Run([], targetValue: 1).Steps;
+
+        bubbleSteps.Should().NotBeEmpty();
+        binaryFoundSteps.Should().NotBeEmpty();
+        binaryNotFoundSteps.Should().NotBeEmpty();
+        binaryEmptySteps.Should().NotBeEmpty();
+
+        bubbleSteps.Should().OnlyContain(step => step.LineNumber > 0);
+        binaryFoundSteps.Should().OnlyContain(step => step.LineNumber > 0);
+        binaryNotFoundSteps.Should().OnlyContain(step => step.LineNumber > 0);
+        binaryEmptySteps.Should().OnlyContain(step => step.LineNumber > 0);
+    }
+
+    [Fact(DisplayName = "UT-SYNC-02 — SimulationStepModel: line_number values fall within valid pseudocode ranges")]
+    public void StepGenerators_ShouldEmitLineNumbersWithinAlgorithmPseudocodeRange()
+    {
+        var bubble = new BubbleSortSimulationEngine();
+        var binary = new BinarySearchSimulationEngine();
+
+        var bubbleCases = new[]
+        {
+            bubble.Run([1, 2, 3, 4]).Steps,
+            bubble.Run([4, 3, 2, 1]).Steps,
+            bubble.Run([42]).Steps,
+            bubble.Run([]).Steps
+        };
+
+        var binaryCases = new[]
+        {
+            binary.Run([3, 7, 12, 19], targetValue: 12).Steps,
+            binary.Run([3, 7, 12, 19], targetValue: -1).Steps,
+            binary.Run([], targetValue: 99).Steps
+        };
+
+        foreach (var steps in bubbleCases)
+        {
+            steps.Should().OnlyContain(step => step.LineNumber >= 1 && step.LineNumber <= 6);
+        }
+
+        foreach (var steps in binaryCases)
+        {
+            steps.Should().OnlyContain(step => step.LineNumber >= 1 && step.LineNumber <= 8);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds and aligns unit tests to improve synchronization confidence between simulation steps and backend behavior, without changing production code.

What I changed

Added new synchronization-focused unit tests in [SimulationSynchronizationTests.cs](vscode-file://vscode-app/c:/Users/hp/AppData/Local/Programs/Microsoft%20VS%20Code/07ff9d6178/resources/app/out/vs/code/electron-browser/workbench/workbench.html):

UT-SYNC-01: verifies line_number is present and non-zero for every generated simulation step.

UT-SYNC-02: verifies line_number is always within valid pseudocode line ranges:

Bubble Sort: 1 to 6

Binary Search: 1 to 8

Updated existing unit tests in [SimulationServiceRunTests.cs](vscode-file://vscode-app/c:/Users/hp/AppData/Local/Programs/Microsoft%20VS%20Code/07ff9d6178/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to match the current backend method signature:

Synchronized RunAsync test calls by passing targetValue as null where applicable.

Kept changes strictly in test code.

Why
These tests protect frontend code-panel highlighting and step synchronization by ensuring every emitted step maps to a valid backend pseudocode line and by keeping test contracts aligned with backend APIs.

Scope

Test code only.
No backend or production logic changes.
Validation
Ran targeted unit tests for synchronization and simulation run behavior; all selected tests passed.