### PR TITLE
Add unit tests for BinarySearchSimulationEngine to validate search fu…

### DIFF
--- a/Testing/UnitTests/Services/SimulationServiceRunTests.cs
+++ b/Testing/UnitTests/Services/SimulationServiceRunTests.cs
@@ -19,7 +19,7 @@ public class SimulationServiceRunTests
     {
         var sut = BuildSut();
 
-        var result = await sut.RunAsync("bubble_sort", [5, 1, 4, 2]);
+        var result = await sut.RunAsync("bubble_sort", [5, 1, 4, 2], null);
 
         result.AlgorithmName.Should().Be("Bubble Sort");
         result.TotalSteps.Should().Be(result.Steps.Count);
@@ -38,7 +38,7 @@ public class SimulationServiceRunTests
     {
         var sut = BuildSut();
 
-        var act = () => sut.RunAsync("unknown_algorithm", [3, 2, 1]);
+        var act = () => sut.RunAsync("unknown_algorithm", [3, 2, 1], null);
 
         await act.Should()
             .ThrowAsync<NotSupportedException>()

--- a/Testing/UnitTests/Services/Simulations/BinarySearchSimulationEngineTests.cs
+++ b/Testing/UnitTests/Services/Simulations/BinarySearchSimulationEngineTests.cs
@@ -6,14 +6,142 @@ namespace backend.Tests.Services.Simulations;
 
 public class BinarySearchSimulationEngineTests
 {
+    private readonly BinarySearchSimulationEngine _sut = new();
+
+    [Fact(DisplayName = "UT-BIN-01 - BinarySearchEngine: target present in odd-length array returns correct step sequence")]
+    public void Run_TargetPresentInOddLengthArray_ProducesCorrectMidpointSequence_AndFoundStep()
+    {
+        var response = _sut.Run([1, 3, 5, 7, 9], 7);
+
+        response.Steps.Should().NotBeEmpty();
+        response.Steps.Last().ActionLabel.Should().Be("found");
+
+        var midpointSteps = response.Steps
+            .Where(step => step.ActionLabel == "midpoint_pick")
+            .ToArray();
+
+        midpointSteps.Should().HaveCount(2);
+        midpointSteps[0].Search!.LowIndex.Should().Be(0);
+        midpointSteps[0].Search.HighIndex.Should().Be(4);
+        midpointSteps[0].Search.MidpointIndex.Should().Be(2);
+
+        midpointSteps[1].Search!.LowIndex.Should().Be(3);
+        midpointSteps[1].Search.HighIndex.Should().Be(4);
+        midpointSteps[1].Search.MidpointIndex.Should().Be(3);
+
+        var foundStep = response.Steps.Last();
+        foundStep.Search.Should().NotBeNull();
+        foundStep.Search!.State.Should().Be("found");
+        foundStep.Search.MidpointIndex.Should().Be(3);
+        foundStep.ActiveIndices.Should().Equal([3]);
+    }
+
+    [Fact(DisplayName = "UT-BIN-02 - BinarySearchEngine: target present at first index is found correctly")]
+    public void Run_TargetAtFirstIndex_IsFoundCorrectly()
+    {
+        var response = _sut.Run([10, 20, 30, 40, 50], 10);
+
+        response.Steps.Last().ActionLabel.Should().Be("found");
+        response.Steps.Last().Search.Should().NotBeNull();
+        response.Steps.Last().Search!.MidpointIndex.Should().Be(0);
+        response.Steps.Last().ActiveIndices.Should().Equal([0]);
+    }
+
+    [Fact(DisplayName = "UT-BIN-03 - BinarySearchEngine: target present at last index is found correctly")]
+    public void Run_TargetAtLastIndex_IsFoundCorrectly()
+    {
+        var response = _sut.Run([10, 20, 30, 40, 50], 50);
+
+        response.Steps.Last().ActionLabel.Should().Be("found");
+        response.Steps.Last().Search.Should().NotBeNull();
+        response.Steps.Last().Search!.MidpointIndex.Should().Be(4);
+        response.Steps.Last().ActiveIndices.Should().Equal([4]);
+    }
+
+    [Fact(DisplayName = "UT-BIN-04 - BinarySearchEngine: target not present returns not-found step")]
+    public void Run_TargetNotPresent_EndsWithNotFound_AndNoActiveIndices()
+    {
+        var response = _sut.Run([1, 3, 5, 7, 9], 8);
+
+        response.Steps.Last().ActionLabel.Should().Be("not_found");
+        response.Steps.Last().Search.Should().NotBeNull();
+        response.Steps.Last().Search!.State.Should().Be("not_found");
+        response.Steps.Last().ActiveIndices.Should().BeEmpty();
+    }
+
+    [Fact(DisplayName = "UT-BIN-05 - BinarySearchEngine: single element array, target matches, returns found in one step")]
+    public void Run_SingleElementArray_TargetMatches_ReturnsFoundInOneMidpointStep()
+    {
+        var response = _sut.Run([42], 42);
+
+        response.Steps.Count(step => step.ActionLabel == "midpoint_pick").Should().Be(1);
+        response.Steps.Count(step => step.ActionLabel == "found").Should().Be(1);
+        response.Steps.Last().ActionLabel.Should().Be("found");
+        response.Steps.Last().ActiveIndices.Should().Equal([0]);
+    }
+
+    [Fact(DisplayName = "UT-BIN-06 - BinarySearchEngine: single element array, target does not match, returns not-found")]
+    public void Run_SingleElementArray_TargetDoesNotMatch_ReturnsNotFound()
+    {
+        var response = _sut.Run([42], 7);
+
+        response.Steps.Last().ActionLabel.Should().Be("not_found");
+        response.Steps.Last().Search.Should().NotBeNull();
+        response.Steps.Last().Search!.State.Should().Be("not_found");
+        response.Steps.Last().ActiveIndices.Should().BeEmpty();
+    }
+
+    [Fact(DisplayName = "UT-BIN-07 - BinarySearchEngine: each step contains correct low, high, mid indices and array_state")]
+    public void Run_EachMidpointStep_HasMathematicallyCorrectIndices_AndStableArrayState()
+    {
+        var response = _sut.Run([1, 3, 5, 7, 9], 9);
+
+        var expectedArrayState = new[] { 1, 3, 5, 7, 9 };
+
+        foreach (var step in response.Steps)
+        {
+            step.ArrayState.Should().Equal(expectedArrayState);
+        }
+
+        var midpointSteps = response.Steps
+            .Where(step => step.ActionLabel == "midpoint_pick")
+            .ToArray();
+
+        midpointSteps.Should().NotBeEmpty();
+
+        foreach (var step in midpointSteps)
+        {
+            step.Search.Should().NotBeNull();
+            var search = step.Search!;
+            var expectedMid = (search.LowIndex + search.HighIndex) / 2;
+
+            search.MidpointIndex.Should().Be(expectedMid);
+            search.LowIndex.Should().BeGreaterThanOrEqualTo(0);
+            search.HighIndex.Should().BeLessThan(expectedArrayState.Length);
+            search.LowIndex.Should().BeLessThanOrEqualTo(search.HighIndex);
+        }
+    }
+
+    [Fact(DisplayName = "UT-BIN-08 - BinarySearchEngine: empty array returns not-found without throwing")]
+    public void Run_EmptyArray_DoesNotThrow_AndReturnsImmediateNotFound()
+    {
+        var act = () => _sut.Run([], 1);
+
+        act.Should().NotThrow();
+
+        var response = _sut.Run([], 1);
+
+        response.Steps.Should().HaveCount(1);
+        response.Steps.Single().ActionLabel.Should().Be("not_found");
+        response.Steps.Single().Search.Should().NotBeNull();
+        response.Steps.Single().Search!.State.Should().Be("not_found");
+        response.Steps.Single().ActiveIndices.Should().BeEmpty();
+    }
+
     [Fact]
     public void Run_AddsSearchMetadataForDiscardSteps()
     {
-        var sut = new BinarySearchSimulationEngine();
-
-        var response = sut.Run([3, 7, 12, 19]);
-
-        response.Steps.Should().NotBeEmpty();
+        var response = _sut.Run([3, 7, 12, 19]);
 
         var discardStep = response.Steps.First(step => step.ActionLabel == "discard_left");
         discardStep.Search.Should().NotBeNull();
@@ -25,9 +153,7 @@ public class BinarySearchSimulationEngineTests
     [Fact]
     public void Run_AddsSearchMetadataForFoundStep()
     {
-        var sut = new BinarySearchSimulationEngine();
-
-        var response = sut.Run([3, 7, 12, 19]);
+        var response = _sut.Run([3, 7, 12, 19]);
 
         var foundStep = response.Steps.First(step => step.ActionLabel == "found");
         foundStep.Search.Should().NotBeNull();


### PR DESCRIPTION
This PR adds and validates Binary Search unit tests in the UnitTests project, focused on step-by-step simulation behavior and boundary conditions.
No backend production logic was changed.

What Changed
Added UT-BIN-01 to UT-BIN-08 in [BinarySearchSimulationEngineTests.cs](vscode-file://vscode-app/c:/Users/hp/AppData/Local/Programs/Microsoft%20VS%20Code/07ff9d6178/resources/app/out/vs/code/electron-browser/workbench/workbench.html).

Covered:
Target present in odd-length array with correct midpoint progression.
Target found at first index.
Target found at last index.
Target not present returns not_found.
Single-element array where target matches.
Single-element array where target does not match.
Per-step verification of low/high/mid correctness and array_state consistency.
Empty array returns immediate not_found without exception.
Updated two test calls in [SimulationServiceRunTests.cs](vscode-file://vscode-app/c:/Users/hp/AppData/Local/Programs/Microsoft%20VS%20Code/07ff9d6178/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to include explicit targetValue argument:
RunAsync("bubble_sort", [5, 1, 4, 2], null)
RunAsync("unknown_algorithm", [3, 2, 1], null)

Why:

Ensure Binary Search simulation output is correct across normal, edge, and failure paths.
Keep test code aligned with current RunAsync signature requiring targetValue.

Validation

Ran:
dotnet test "Testing/UnitTests/UnitTests.csproj" --filter "FullyQualifiedName~BinarySearchSimulationEngineTests"

Result:
10 passed, 0 failed, 0 skipped.
Scope / Safety
Test-only changes.
No API, service, controller, repository, or algorithm engine production code changes.