### PR TITLE
Bug fix :Require target for binary search run requests

### DIFF
--- a/Controllers/SimulationController.cs
+++ b/Controllers/SimulationController.cs
@@ -48,6 +48,15 @@ public class SimulationController : ControllerBase
                 ModelState.AddModelError(nameof(dto.Array), "Array must contain at least one value.");
             }
 
+            if (!string.IsNullOrWhiteSpace(dto.Algorithm))
+            {
+                var normalizedAlgorithm = dto.Algorithm.Trim().ToLowerInvariant();
+                if (normalizedAlgorithm is "binary_search" or "binary-search" && dto.Target is null)
+                {
+                    ModelState.AddModelError(nameof(dto.Target), "Target is required for binary search.");
+                }
+            }
+
             if (!ModelState.IsValid)
             {
                 return ValidationProblem(ModelState);


### PR DESCRIPTION
Enforce target validation when algorithm is binary search in /api/simulation/run. 

Return 400 with a clear validation error when target is missing.

Keeps behavior unchanged for other algorithms; binary search tests should pass.