### PR TITLE
feat: add release pipeline with post-deployment health check and noti…

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -1,0 +1,147 @@
+name: Release Pipeline
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --configuration Release --no-restore
+
+      - name: Run Unit Tests
+        run: dotnet test Testing/UnitTests/UnitTests.csproj --configuration Release --no-build
+
+      - name: Run Integration Tests
+        run: dotnet test Testing/IntegrationTests/IntegrationTests.csproj --configuration Release --no-build
+
+      - name: Extract code coverage
+        id: coverage
+        run: |
+          # Read coverage value from Cobertura report
+          COVERAGE=$(grep -oPm1 "(?<=<coverage line-rate=\")[^\"]+" TestResults/**/coverage.cobertura.xml)
+          PERCENT=$(echo "$COVERAGE * 100" | bc | cut -d'.' -f1)
+          echo "Coverage is $PERCENT%"
+          echo "coverage=$PERCENT" >> $GITHUB_OUTPUT
+
+      - name: Check Coverage Threshold
+        run: |
+          if [ "${{ steps.coverage.outputs.coverage }}" -lt 70 ]; then
+            echo "Coverage below 70% — deployment blocked!"
+            exit 1
+          else
+            echo "Coverage is sufficient — deployment continues"
+          fi
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Deploy Application
+        run: |
+          echo "Deploying application to production..."
+
+      - name: Wait for Deployment
+        run: sleep 30
+
+      - name: Post-Deployment Health Check
+        id: health-check
+        run: |
+          max_attempts=30
+          attempt=1
+          health_status="FAILED"
+          deployment_url="${{ secrets.DEPLOYMENT_URL }}"
+          
+          echo "Starting health checks against: $deployment_url/api/health"
+          
+          while [ $attempt -le $max_attempts ]; do
+            echo "[Attempt $attempt/$max_attempts] Polling health endpoint..."
+            
+            response=$(curl -s -w "\n%{http_code}" "$deployment_url/api/health" 2>&1)
+            http_code=$(echo "$response" | tail -n1)
+            body=$(echo "$response" | head -n-1)
+            
+            echo "HTTP Status: $http_code"
+            echo "Response: $body"
+            
+            if [ "$http_code" = "200" ]; then
+              echo "✓ SUCCESS: Health check passed - Service is healthy"
+              health_status="SUCCESS"
+              break
+            fi
+            
+            if [ $attempt -eq $max_attempts ]; then
+              echo "✗ FAILURE: Max attempts reached. Service failed health verification."
+              break
+            fi
+            
+            echo "Health endpoint returned HTTP $http_code. Retrying in 10 seconds..."
+            sleep 10
+            attempt=$((attempt + 1))
+          done
+          
+          echo "health_status=$health_status" >> $GITHUB_OUTPUT
+          
+          if [ "$health_status" = "FAILED" ]; then
+            exit 1
+          fi
+
+      - name: Notify Team - Deployment Success
+        if: success()
+        uses: 8398a7/action-slack@v3
+        with:
+          status: success
+          title: '✓ Deployment Successful'
+          text: 'Release ${{ github.ref_name }} deployed successfully with healthy /api/health endpoint returning HTTP 200'
+          webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          fields: |
+            repo
+            message
+            commit
+            author
+
+      - name: Notify Team - Health Check Failed
+        if: failure() && steps.health-check.outputs.health_status == 'FAILED'
+        uses: 8398a7/action-slack@v3
+        with:
+          status: failure
+          title: '✗ Deployment Failed - Health Check'
+          text: 'Release ${{ github.ref_name }}: POST-DEPLOYMENT HEALTH CHECK FAILED. The /api/health endpoint is not returning HTTP 200. Immediate investigation required!'
+          webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          mention: 'channel'
+          fields: |
+            repo
+            message
+            commit
+            author
+
+      - name: Notify Team - Build Failed
+        if: failure() && steps.health-check.outputs.health_status != 'FAILED'
+        uses: 8398a7/action-slack@v3
+        with:
+          status: failure
+          title: '✗ Pipeline Failed'
+          text: 'Release ${{ github.ref_name }} pipeline failed during build or deployment'
+          webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          fields: |
+            repo
+            message
+            commit


### PR DESCRIPTION
I added the Slack URL to the GitHub secrets, and if a pull request fails due to a health check error, it will show directly in the Slack workspace 