### PR TITLE
Sa 125 write new db migration adding badges and user badg

### DIFF
--- a/Controllers/BadgeController.cs
+++ b/Controllers/BadgeController.cs
@@ -1,0 +1,149 @@
+using backend.DTOs;
+using backend.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace backend.Controllers;
+
+/// <summary>
+/// API endpoints for badge management and unlock tracking.
+/// </summary>
+[ApiController]
+[Route("api/[controller]")]
+public class BadgeController : ControllerBase
+{
+    private readonly IBadgeService _badgeService;
+    private readonly ILogger<BadgeController> _logger;
+
+    public BadgeController(IBadgeService badgeService, ILogger<BadgeController> logger)
+    {
+        _badgeService = badgeService;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Retrieves all available badges sorted by XP threshold.
+    /// </summary>
+    [HttpGet]
+    [ProducesResponseType(typeof(IEnumerable<BadgeResponseDto>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetAllBadges()
+    {
+        try
+        {
+            var badges = await _badgeService.GetAllBadgesAsync();
+            return Ok(badges);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error retrieving all badges");
+            return StatusCode(500, new { message = "An error occurred while retrieving badges" });
+        }
+    }
+
+    /// <summary>
+    /// Retrieves a specific badge by ID.
+    /// </summary>
+    [HttpGet("{badgeId}")]
+    [ProducesResponseType(typeof(BadgeResponseDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetBadgeById(int badgeId)
+    {
+        try
+        {
+            var badge = await _badgeService.GetBadgeByIdAsync(badgeId);
+            if (badge == null)
+                return NotFound(new { message = $"Badge with ID {badgeId} not found" });
+
+            return Ok(badge);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error retrieving badge {BadgeId}", badgeId);
+            return StatusCode(500, new { message = "An error occurred while retrieving the badge" });
+        }
+    }
+
+    /// <summary>
+    /// Retrieves all badges earned by a specific user.
+    /// </summary>
+    [HttpGet("user/{userId}/earned")]
+    [ProducesResponseType(typeof(IEnumerable<BadgeResponseDto>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetUserEarnedBadges(int userId)
+    {
+        try
+        {
+            var badges = await _badgeService.GetUserEarnedBadgesAsync(userId);
+            return Ok(badges);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error retrieving earned badges for user {UserId}", userId);
+            return StatusCode(500, new { message = "An error occurred while retrieving user badges" });
+        }
+    }
+
+    /// <summary>
+    /// Retrieves all badges available (unlocked by XP) but not yet awarded to a user.
+    /// </summary>
+    [HttpGet("user/{userId}/available")]
+    [ProducesResponseType(typeof(IEnumerable<BadgeResponseDto>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetUserAvailableBadges(int userId)
+    {
+        try
+        {
+            var badges = await _badgeService.GetUserAvailableBadgesAsync(userId);
+            return Ok(badges);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error retrieving available badges for user {UserId}", userId);
+            return StatusCode(500, new { message = "An error occurred while retrieving available badges" });
+        }
+    }
+
+    /// <summary>
+    /// Automatically awards any unlocked badges to a user based on their current XP.
+    /// </summary>
+    [HttpPost("user/{userId}/award-unlocked")]
+    [ProducesResponseType(typeof(IEnumerable<BadgeResponseDto>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> AwardUnlockedBadges(int userId)
+    {
+        try
+        {
+            var awardedBadges = await _badgeService.AwardUnlockedBadgesAsync(userId);
+            return Ok(new
+            {
+                message = "Badges awarded successfully",
+                awardedBadges
+            });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error awarding unlocked badges to user {UserId}", userId);
+            return StatusCode(500, new { message = "An error occurred while awarding badges" });
+        }
+    }
+
+    /// <summary>
+    /// Manually awards a specific badge to a user.
+    /// </summary>
+    [HttpPost("user/{userId}/award/{badgeId}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
+    public async Task<IActionResult> AwardBadge(int userId, int badgeId)
+    {
+        try
+        {
+            var success = await _badgeService.AwardBadgeAsync(userId, badgeId);
+            if (!success)
+                return Conflict(new { message = "Badge already awarded to user or invalid user/badge" });
+
+            return Ok(new { message = "Badge awarded successfully" });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error awarding badge {BadgeId} to user {UserId}", badgeId, userId);
+            return StatusCode(500, new { message = "An error occurred while awarding the badge" });
+        }
+    }
+}

--- a/DTOs/BadgeResponseDto.cs
+++ b/DTOs/BadgeResponseDto.cs
@@ -1,0 +1,12 @@
+namespace backend.DTOs;
+
+/// <summary>
+/// DTO for badge responses in API endpoints.
+/// </summary>
+public class BadgeResponseDto
+{
+    public int BadgeId { get; set; }
+    public string BadgeName { get; set; } = string.Empty;
+    public string BadgeDescription { get; set; } = string.Empty;
+    public int XpThreshold { get; set; }
+}

--- a/Models/Badge.cs
+++ b/Models/Badge.cs
@@ -1,0 +1,17 @@
+namespace backend.Models;
+
+/// <summary>
+/// Domain model representing a row in the badges table.
+/// Stores badge definitions with XP thresholds.
+/// </summary>
+public class Badge
+{
+    public int BadgeId { get; set; }
+    public string BadgeName { get; set; } = string.Empty;
+    public string BadgeDescription { get; set; } = string.Empty;
+    public int XpThreshold { get; set; }
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+    // Navigation property
+    public ICollection<UserBadge> UserBadges { get; set; } = new List<UserBadge>();
+}

--- a/Models/User.cs
+++ b/Models/User.cs
@@ -14,4 +14,7 @@ public class User
     public bool IsActive { get; set; } = true;
     public DateTime CreatedAt { get; set; }
     public DateTime UpdatedAt { get; set; }
+
+    // Navigation properties
+    public ICollection<UserBadge> UserBadges { get; set; } = new List<UserBadge>();
 }

--- a/Models/UserBadge.cs
+++ b/Models/UserBadge.cs
@@ -1,0 +1,17 @@
+namespace backend.Models;
+
+/// <summary>
+/// Domain model representing a row in the user_badges table.
+/// Tracks badge awards for users.
+/// </summary>
+public class UserBadge
+{
+    public int UserBadgeId { get; set; }
+    public int UserId { get; set; }
+    public int BadgeId { get; set; }
+    public DateTime AwardedAt { get; set; } = DateTime.UtcNow;
+
+    // Navigation properties
+    public User? User { get; set; }
+    public Badge? Badge { get; set; }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -266,6 +266,8 @@ builder.Services.AddScoped<IQuizAttemptRepository, QuizAttemptRepository>();
 builder.Services.AddScoped<IQuizAttemptService, QuizAttemptService>();
 builder.Services.AddScoped<ICodingQuestionRepository, CodingQuestionRepository>();
 builder.Services.AddScoped<ICodingQuestionService, CodingQuestionService>();
+builder.Services.AddScoped<IBadgeRepository, BadgeRepository>();
+builder.Services.AddScoped<IBadgeService, BadgeService>();
 builder.Services.AddScoped<ISimulationService, SimulationService>();
 builder.Services.AddScoped<IAlgorithmSimulationEngine, BubbleSortSimulationEngine>();
 builder.Services.AddScoped<IAlgorithmSimulationEngine, InsertionSortSimulationEngine>();

--- a/Repositories/BadgeRepository.cs
+++ b/Repositories/BadgeRepository.cs
@@ -1,0 +1,214 @@
+using backend.Data;
+using backend.Models;
+using MySql.Data.MySqlClient;
+
+namespace backend.Repositories;
+
+/// <summary>
+/// ADO.NET implementation of <see cref="IBadgeRepository"/>.
+/// Uses parameterized queries to prevent SQL injection.
+/// </summary>
+public class BadgeRepository : IBadgeRepository
+{
+    private readonly DatabaseHelper _db;
+
+    public BadgeRepository(DatabaseHelper db)
+    {
+        _db = db;
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<Badge>> GetAllAsync()
+    {
+        const string sql = @"
+            SELECT badge_id, badge_name, badge_description, xp_threshold, created_at
+            FROM badges
+            ORDER BY xp_threshold ASC;";
+
+        await using var connection = await _db.OpenConnectionAsync();
+        await using var cmd = new MySqlCommand(sql, connection);
+
+        var badges = new List<Badge>();
+        await using var reader = (MySqlDataReader)await cmd.ExecuteReaderAsync();
+
+        while (await reader.ReadAsync())
+        {
+            badges.Add(MapBadge(reader));
+        }
+
+        return badges;
+    }
+
+    /// <inheritdoc />
+    public async Task<Badge?> GetByIdAsync(int badgeId)
+    {
+        const string sql = @"
+            SELECT badge_id, badge_name, badge_description, xp_threshold, created_at
+            FROM badges
+            WHERE badge_id = @BadgeId
+            LIMIT 1;";
+
+        await using var connection = await _db.OpenConnectionAsync();
+        await using var cmd = new MySqlCommand(sql, connection);
+        cmd.Parameters.AddWithValue("@BadgeId", badgeId);
+
+        await using var reader = (MySqlDataReader)await cmd.ExecuteReaderAsync();
+
+        if (!await reader.ReadAsync())
+            return null;
+
+        return MapBadge(reader);
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<Badge>> GetEarnedBadgesByUserIdAsync(int userId)
+    {
+        const string sql = @"
+            SELECT b.badge_id, b.badge_name, b.badge_description, b.xp_threshold, b.created_at
+            FROM badges b
+            INNER JOIN user_badges ub ON b.badge_id = ub.badge_id
+            WHERE ub.user_id = @UserId
+            ORDER BY b.xp_threshold ASC;";
+
+        await using var connection = await _db.OpenConnectionAsync();
+        await using var cmd = new MySqlCommand(sql, connection);
+        cmd.Parameters.AddWithValue("@UserId", userId);
+
+        var badges = new List<Badge>();
+        await using var reader = (MySqlDataReader)await cmd.ExecuteReaderAsync();
+
+        while (await reader.ReadAsync())
+        {
+            badges.Add(MapBadge(reader));
+        }
+
+        return badges;
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<Badge>> GetUnlockedBadgesByUserIdAsync(int userId)
+    {
+        const string sql = @"
+            SELECT b.badge_id, b.badge_name, b.badge_description, b.xp_threshold, b.created_at
+            FROM badges b
+            WHERE b.xp_threshold <= (SELECT xp_total FROM users WHERE id = @UserId)
+            AND b.badge_id NOT IN (
+                SELECT badge_id FROM user_badges WHERE user_id = @UserId
+            )
+            ORDER BY b.xp_threshold ASC;";
+
+        await using var connection = await _db.OpenConnectionAsync();
+        await using var cmd = new MySqlCommand(sql, connection);
+        cmd.Parameters.AddWithValue("@UserId", userId);
+
+        var badges = new List<Badge>();
+        await using var reader = (MySqlDataReader)await cmd.ExecuteReaderAsync();
+
+        while (await reader.ReadAsync())
+        {
+            badges.Add(MapBadge(reader));
+        }
+
+        return badges;
+    }
+
+    /// <inheritdoc />
+    public async Task<Badge> CreateAsync(Badge badge)
+    {
+        const string sql = @"
+            INSERT INTO badges (badge_name, badge_description, xp_threshold)
+            VALUES (@BadgeName, @BadgeDescription, @XpThreshold);
+            SELECT LAST_INSERT_ID();";
+
+        await using var connection = await _db.OpenConnectionAsync();
+        await using var cmd = new MySqlCommand(sql, connection);
+
+        cmd.Parameters.AddWithValue("@BadgeName", badge.BadgeName);
+        cmd.Parameters.AddWithValue("@BadgeDescription", badge.BadgeDescription);
+        cmd.Parameters.AddWithValue("@XpThreshold", badge.XpThreshold);
+
+        var id = (long?)await cmd.ExecuteScalarAsync() ?? 0;
+        badge.BadgeId = (int)id;
+
+        return badge;
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> UpdateAsync(int badgeId, Badge badge)
+    {
+        const string sql = @"
+            UPDATE badges
+            SET badge_name = @BadgeName,
+                badge_description = @BadgeDescription,
+                xp_threshold = @XpThreshold
+            WHERE badge_id = @BadgeId;";
+
+        await using var connection = await _db.OpenConnectionAsync();
+        await using var cmd = new MySqlCommand(sql, connection);
+
+        cmd.Parameters.AddWithValue("@BadgeId", badgeId);
+        cmd.Parameters.AddWithValue("@BadgeName", badge.BadgeName);
+        cmd.Parameters.AddWithValue("@BadgeDescription", badge.BadgeDescription);
+        cmd.Parameters.AddWithValue("@XpThreshold", badge.XpThreshold);
+
+        var rowsAffected = await cmd.ExecuteNonQueryAsync();
+        return rowsAffected > 0;
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> DeleteAsync(int badgeId)
+    {
+        const string sql = "DELETE FROM badges WHERE badge_id = @BadgeId;";
+
+        await using var connection = await _db.OpenConnectionAsync();
+        await using var cmd = new MySqlCommand(sql, connection);
+        cmd.Parameters.AddWithValue("@BadgeId", badgeId);
+
+        var rowsAffected = await cmd.ExecuteNonQueryAsync();
+        return rowsAffected > 0;
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> AwardBadgeToUserAsync(int userId, int badgeId)
+    {
+        const string sql = @"
+            INSERT INTO user_badges (user_id, badge_id)
+            VALUES (@UserId, @BadgeId);";
+
+        try
+        {
+            await using var connection = await _db.OpenConnectionAsync();
+            await using var cmd = new MySqlCommand(sql, connection);
+            cmd.Parameters.AddWithValue("@UserId", userId);
+            cmd.Parameters.AddWithValue("@BadgeId", badgeId);
+
+            var rowsAffected = await cmd.ExecuteNonQueryAsync();
+            return rowsAffected > 0;
+        }
+        catch (MySqlException ex) when (ex.Number == 1062) // Duplicate key error
+        {
+            // Badge already awarded to this user
+            return false;
+        }
+        catch (MySqlException ex) when (ex.Number == 1452) // Foreign key constraint fails
+        {
+            // Invalid user_id or badge_id
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Maps a MySqlDataReader row to a Badge object.
+    /// </summary>
+    private static Badge MapBadge(MySqlDataReader reader)
+    {
+        return new Badge
+        {
+            BadgeId = (int)reader["badge_id"],
+            BadgeName = (string)reader["badge_name"],
+            BadgeDescription = (string)reader["badge_description"],
+            XpThreshold = (int)(uint)reader["xp_threshold"],  // xp_threshold is UNSIGNED INT
+            CreatedAt = (DateTime)reader["created_at"]
+        };
+    }
+}

--- a/Repositories/IBadgeRepository.cs
+++ b/Repositories/IBadgeRepository.cs
@@ -1,0 +1,52 @@
+using backend.Models;
+
+namespace backend.Repositories;
+
+/// <summary>
+/// Defines data-access operations for the badges table.
+/// </summary>
+public interface IBadgeRepository
+{
+    /// <summary>
+    /// Retrieves all badges sorted by XP threshold.
+    /// </summary>
+    Task<IEnumerable<Badge>> GetAllAsync();
+
+    /// <summary>
+    /// Retrieves a badge by its ID.
+    /// </summary>
+    Task<Badge?> GetByIdAsync(int badgeId);
+
+    /// <summary>
+    /// Retrieves badges that a user has earned based on their XP total.
+    /// </summary>
+    Task<IEnumerable<Badge>> GetEarnedBadgesByUserIdAsync(int userId);
+
+    /// <summary>
+    /// Retrieves badges that a user has NOT yet earned based on their XP total.
+    /// </summary>
+    Task<IEnumerable<Badge>> GetUnlockedBadgesByUserIdAsync(int userId);
+
+    /// <summary>
+    /// Inserts a new badge and returns the created record with the generated ID.
+    /// </summary>
+    Task<Badge> CreateAsync(Badge badge);
+
+    /// <summary>
+    /// Updates an existing badge.
+    /// Returns true if successful, false if the badge was not found.
+    /// </summary>
+    Task<bool> UpdateAsync(int badgeId, Badge badge);
+
+    /// <summary>
+    /// Deletes a badge.
+    /// Returns true if successful, false if the badge was not found.
+    /// </summary>
+    Task<bool> DeleteAsync(int badgeId);
+
+    /// <summary>
+    /// Awards a badge to a user (inserts into user_badges table).
+    /// Returns true if successful, false if user/badge doesn't exist or already awarded.
+    /// </summary>
+    Task<bool> AwardBadgeToUserAsync(int userId, int badgeId);
+}

--- a/Services/BadgeService.cs
+++ b/Services/BadgeService.cs
@@ -1,0 +1,111 @@
+using backend.DTOs;
+using backend.Models;
+using backend.Repositories;
+
+namespace backend.Services;
+
+/// <summary>
+/// Business logic implementation for badge management.
+/// </summary>
+public class BadgeService : IBadgeService
+{
+    private readonly IBadgeRepository _badgeRepository;
+    private readonly IUserRepository _userRepository;
+
+    public BadgeService(IBadgeRepository badgeRepository, IUserRepository userRepository)
+    {
+        _badgeRepository = badgeRepository;
+        _userRepository = userRepository;
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<BadgeResponseDto>> GetAllBadgesAsync()
+    {
+        var badges = await _badgeRepository.GetAllAsync();
+        return badges.Select(MapToDto);
+    }
+
+    /// <inheritdoc />
+    public async Task<BadgeResponseDto?> GetBadgeByIdAsync(int badgeId)
+    {
+        var badge = await _badgeRepository.GetByIdAsync(badgeId);
+        return badge == null ? null : MapToDto(badge);
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<BadgeResponseDto>> GetUserEarnedBadgesAsync(int userId)
+    {
+        var badges = await _badgeRepository.GetEarnedBadgesByUserIdAsync(userId);
+        return badges.Select(MapToDto);
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<BadgeResponseDto>> GetUserAvailableBadgesAsync(int userId)
+    {
+        var badges = await _badgeRepository.GetUnlockedBadgesByUserIdAsync(userId);
+        return badges.Select(MapToDto);
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<BadgeResponseDto>> AwardUnlockedBadgesAsync(int userId)
+    {
+        // Get the user's current XP
+        var user = await _userRepository.GetByIdAsync(userId);
+        if (user == null)
+            return Enumerable.Empty<BadgeResponseDto>();
+
+        // Get all badges that user hasn't earned yet but XP qualifies for
+        var unlockedBadges = await _badgeRepository.GetUnlockedBadgesByUserIdAsync(userId);
+        var awards = new List<BadgeResponseDto>();
+
+        foreach (var badge in unlockedBadges)
+        {
+            // Award the badge
+            var success = await AwardBadgeAsync(userId, badge.BadgeId);
+            if (success)
+            {
+                awards.Add(MapToDto(badge));
+            }
+        }
+
+        return awards;
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> AwardBadgeAsync(int userId, int badgeId)
+    {
+        // Verify user exists
+        var user = await _userRepository.GetByIdAsync(userId);
+        if (user == null)
+            return false;
+
+        // Verify badge exists
+        var badge = await _badgeRepository.GetByIdAsync(badgeId);
+        if (badge == null)
+            return false;
+
+        // Award the badge
+        return await _badgeRepository.AwardBadgeToUserAsync(userId, badgeId);
+    }
+
+    /// <inheritdoc />
+    public async Task<BadgeResponseDto> CreateBadgeAsync(Badge badge)
+    {
+        var created = await _badgeRepository.CreateAsync(badge);
+        return MapToDto(created);
+    }
+
+    /// <summary>
+    /// Maps a Badge domain model to a BadgeResponseDto.
+    /// </summary>
+    private static BadgeResponseDto MapToDto(Badge badge)
+    {
+        return new BadgeResponseDto
+        {
+            BadgeId = badge.BadgeId,
+            BadgeName = badge.BadgeName,
+            BadgeDescription = badge.BadgeDescription,
+            XpThreshold = badge.XpThreshold
+        };
+    }
+}

--- a/Services/IBadgeService.cs
+++ b/Services/IBadgeService.cs
@@ -1,0 +1,47 @@
+using backend.DTOs;
+using backend.Models;
+
+namespace backend.Services;
+
+/// <summary>
+/// Defines business logic operations for badge awarding and retrieval.
+/// </summary>
+public interface IBadgeService
+{
+    /// <summary>
+    /// Retrieves all available badges.
+    /// </summary>
+    Task<IEnumerable<BadgeResponseDto>> GetAllBadgesAsync();
+
+    /// <summary>
+    /// Retrieves a badge by its ID.
+    /// </summary>
+    Task<BadgeResponseDto?> GetBadgeByIdAsync(int badgeId);
+
+    /// <summary>
+    /// Retrieves all badges earned by a user.
+    /// </summary>
+    Task<IEnumerable<BadgeResponseDto>> GetUserEarnedBadgesAsync(int userId);
+
+    /// <summary>
+    /// Retrieves all badges that are unlocked but not yet awarded to a user.
+    /// </summary>
+    Task<IEnumerable<BadgeResponseDto>> GetUserAvailableBadgesAsync(int userId);
+
+    /// <summary>
+    /// Automatically awards any unlocked badges to a user based on their XP.
+    /// Returns the list of newly awarded badges.
+    /// </summary>
+    Task<IEnumerable<BadgeResponseDto>> AwardUnlockedBadgesAsync(int userId);
+
+    /// <summary>
+    /// Manually awards a badge to a user.
+    /// Returns true if successful, false if badge already awarded or user/badge doesn't exist.
+    /// </summary>
+    Task<bool> AwardBadgeAsync(int userId, int badgeId);
+
+    /// <summary>
+    /// Creates a new badge.
+    /// </summary>
+    Task<BadgeResponseDto> CreateBadgeAsync(Badge badge);
+}

--- a/migrations/V008__create_badges_and_user_badges.sql
+++ b/migrations/V008__create_badges_and_user_badges.sql
@@ -1,0 +1,69 @@
+-- =============================================================================
+-- Migration: V008__create_badges_and_user_badges.sql
+-- Feature:   Badges & User Badge Awards
+-- Author:    BigO Dev Team
+-- Date:      2026-04-10
+-- =============================================================================
+-- Adds badge definitions with XP thresholds and a user_badges join table.
+-- Idempotent: safe to re-run; uses IF NOT EXISTS and ON DUPLICATE KEY UPDATE.
+-- =============================================================================
+
+-- -----------------------------------------------------------------------------
+-- Table: badges
+-- Stores the badge catalog and required XP threshold for each badge.
+-- -----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS badges (
+    badge_id           INT NOT NULL AUTO_INCREMENT,
+    badge_name         VARCHAR(100) NOT NULL,
+    badge_description  VARCHAR(255) NOT NULL,
+    xp_threshold       INT UNSIGNED NOT NULL,
+    created_at         DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    PRIMARY KEY (badge_id),
+    UNIQUE KEY uq_badges_name (badge_name)
+) ENGINE=InnoDB;
+
+-- -----------------------------------------------------------------------------
+-- Table: user_badges
+-- Tracks badge awards for users.
+-- -----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS user_badges (
+    user_badge_id      INT NOT NULL AUTO_INCREMENT,
+    user_id            INT NOT NULL,
+    badge_id           INT NOT NULL,
+    awarded_at         DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    PRIMARY KEY (user_badge_id),
+    UNIQUE KEY uq_user_badges_user_badge (user_id, badge_id),
+
+    FOREIGN KEY (user_id)
+        REFERENCES users (id)
+        ON DELETE CASCADE
+        ON UPDATE CASCADE,
+
+    FOREIGN KEY (badge_id)
+        REFERENCES badges (badge_id)
+        ON DELETE RESTRICT
+        ON UPDATE CASCADE
+) ENGINE=InnoDB;
+
+CREATE INDEX idx_user_badges_user
+    ON user_badges (user_id, awarded_at);
+
+CREATE INDEX idx_user_badges_badge
+    ON user_badges (badge_id);
+
+-- -----------------------------------------------------------------------------
+-- Seed: badge catalog
+-- At least 5 default badges with XP thresholds.
+-- -----------------------------------------------------------------------------
+INSERT INTO badges (badge_name, badge_description, xp_threshold)
+VALUES
+    ('First Steps',     'Earned after reaching 50 XP.',     50),
+    ('Quick Learner',   'Earned after reaching 150 XP.',   150),
+    ('Problem Solver',  'Earned after reaching 300 XP.',   300),
+    ('Algorithm Ace',   'Earned after reaching 600 XP.',   600),
+    ('Big O Master',    'Earned after reaching 1000 XP.', 1000)
+ON DUPLICATE KEY UPDATE
+    badge_description = VALUES(badge_description),
+    xp_threshold = VALUES(xp_threshold);


### PR DESCRIPTION
A new database migration: migrations/V008__create_badges_and_user_badges.sql

Creates badges and user_badges
Adds foreign keys to [users](vscode-file://vscode-app/c:/Users/hp/AppData/Local/Programs/Microsoft%20VS%20Code/41dd792b5e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and badges
Seeds 5 badges with XP thresholds
New model classes:

Models/Badge.cs
Models/UserBadge.cs
Updated existing user model:

Models/User.cs now includes a [UserBadges](vscode-file://vscode-app/c:/Users/hp/AppData/Local/Programs/Microsoft%20VS%20Code/41dd792b5e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) navigation property
New repository layer:

Repositories/IBadgeRepository.cs
Repositories/BadgeRepository.cs
Handles badge queries, badge creation, and awarding badges to users
New service layer:

Services/IBadgeService.cs
Services/BadgeService.cs
Handles badge business logic and awarding logic
New DTO:

DTOs/BadgeResponseDto.cs
New API controller:

Controllers/BadgeController.cs
Exposes badge endpoints for list, single badge, earned badges, available badges, and awarding
Dependency injection updated:

Program.cs now registers the badge repository and badge service
Testing result:

The project builds successfully
GET /api/badge returns the 5 seeded badges
GET /api/badge/1 works too
The 5 seeded badges are:

First Steps — 50 XP
Quick Learner — 150 XP
Problem Solver — 300 XP
Algorithm Ace — 600 XP
Big O Master — 1000 XP
