### PR TITLE
Sa 265 write unit tests for all analytics aggregation service methods

### DIFF
--- a/Testing/UnitTests/Services/AdminServiceTests.cs
+++ b/Testing/UnitTests/Services/AdminServiceTests.cs
@@ -1,0 +1,133 @@
+using backend.Models;
+using backend.Repositories;
+using backend.Services;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace backend.Tests.Services;
+
+public class AdminServiceTests
+{
+    private static AdminService BuildSut(
+        Mock<IUserRepository> userRepository,
+        Mock<IQuizRepository> quizRepository,
+        Mock<IQuizAttemptRepository> attemptRepository)
+        => new(
+            userRepository.Object,
+            quizRepository.Object,
+            attemptRepository.Object,
+            NullLogger<AdminService>.Instance);
+
+    [Fact(DisplayName = "GetPlatformStatsAsync computes totals and pass rate")]
+    public async Task GetPlatformStatsAsync_WithAttempts_ComputesExpectedStats()
+    {
+        var userRepository = new Mock<IUserRepository>();
+        var quizRepository = new Mock<IQuizRepository>();
+        var attemptRepository = new Mock<IQuizAttemptRepository>();
+
+        userRepository
+            .Setup(r => r.GetAllAsync())
+            .ReturnsAsync(new[]
+            {
+                new User { UserId = 1, Username = "alice", Email = "a@example.com", XpTotal = 120 },
+                new User { UserId = 2, Username = "bob", Email = "b@example.com", XpTotal = 90 },
+                new User { UserId = 3, Username = "cara", Email = "c@example.com", XpTotal = 60 }
+            });
+
+        quizRepository
+            .Setup(r => r.GetAllAsync())
+            .ReturnsAsync(new[]
+            {
+                new Quiz { QuizId = 1, Title = "Q1" },
+                new Quiz { QuizId = 2, Title = "Q2" }
+            });
+
+        attemptRepository
+            .Setup(r => r.GetAllAsync())
+            .ReturnsAsync(new[]
+            {
+                new QuizAttempt { AttemptId = 1, UserId = 1, QuizId = 1, Score = 80, Passed = true },
+                new QuizAttempt { AttemptId = 2, UserId = 2, QuizId = 2, Score = 70, Passed = false },
+                new QuizAttempt { AttemptId = 3, UserId = 3, QuizId = 1, Score = 90, Passed = true }
+            });
+
+        var result = await BuildSut(userRepository, quizRepository, attemptRepository)
+            .GetPlatformStatsAsync();
+
+        result.TotalUsers.Should().Be(3);
+        result.TotalQuizzes.Should().Be(2);
+        result.TotalAttempts.Should().Be(3);
+        result.AveragePassRate.Should().BeApproximately(66.6667, 0.0001);
+    }
+
+    [Fact(DisplayName = "GetPlatformStatsAsync returns zero pass rate when no attempts exist")]
+    public async Task GetPlatformStatsAsync_NoAttempts_ReturnsZeroPassRate()
+    {
+        var userRepository = new Mock<IUserRepository>();
+        var quizRepository = new Mock<IQuizRepository>();
+        var attemptRepository = new Mock<IQuizAttemptRepository>();
+
+        userRepository.Setup(r => r.GetAllAsync()).ReturnsAsync(Array.Empty<User>());
+        quizRepository.Setup(r => r.GetAllAsync()).ReturnsAsync(Array.Empty<Quiz>());
+        attemptRepository.Setup(r => r.GetAllAsync()).ReturnsAsync(Array.Empty<QuizAttempt>());
+
+        var result = await BuildSut(userRepository, quizRepository, attemptRepository)
+            .GetPlatformStatsAsync();
+
+        result.TotalUsers.Should().Be(0);
+        result.TotalQuizzes.Should().Be(0);
+        result.TotalAttempts.Should().Be(0);
+        result.AveragePassRate.Should().Be(0);
+    }
+
+    [Fact(DisplayName = "GetLeaderboardAsync sorts by XP and assigns tie-aware ranks")]
+    public async Task GetLeaderboardAsync_AssignsRanksAndAggregatesAttemptData()
+    {
+        var userRepository = new Mock<IUserRepository>();
+        var quizRepository = new Mock<IQuizRepository>();
+        var attemptRepository = new Mock<IQuizAttemptRepository>();
+
+        userRepository
+            .Setup(r => r.GetAllAsync())
+            .ReturnsAsync(new[]
+            {
+                new User { UserId = 1, Username = "alice", Email = "a@example.com", XpTotal = 300 },
+                new User { UserId = 2, Username = "bob", Email = "b@example.com", XpTotal = 300 },
+                new User { UserId = 3, Username = "cara", Email = "c@example.com", XpTotal = 120 }
+            });
+
+        attemptRepository
+            .Setup(r => r.GetAllAsync())
+            .ReturnsAsync(new[]
+            {
+                new QuizAttempt { AttemptId = 10, UserId = 1, QuizId = 1, Score = 80, Passed = true },
+                new QuizAttempt { AttemptId = 11, UserId = 1, QuizId = 2, Score = 60, Passed = true },
+                new QuizAttempt { AttemptId = 12, UserId = 3, QuizId = 3, Score = 90, Passed = true }
+            });
+
+        var result = (await BuildSut(userRepository, quizRepository, attemptRepository)
+            .GetLeaderboardAsync()).ToList();
+
+        result.Should().HaveCount(3);
+
+        result[0].UserId.Should().Be(1);
+        result[0].Rank.Should().Be(1);
+        result[0].AttemptCount.Should().Be(2);
+        result[0].AverageScore.Should().BeApproximately(70.0, 0.0001);
+
+        result[1].UserId.Should().Be(2);
+        result[1].Rank.Should().Be(1);
+        result[1].AttemptCount.Should().Be(0);
+        result[1].AverageScore.Should().Be(0);
+
+        result[2].UserId.Should().Be(3);
+        result[2].Rank.Should().Be(3);
+        result[2].AttemptCount.Should().Be(1);
+        result[2].AverageScore.Should().BeApproximately(90.0, 0.0001);
+
+        userRepository.Verify(r => r.GetAllAsync(), Times.Once);
+        attemptRepository.Verify(r => r.GetAllAsync(), Times.Once);
+    }
+}

--- a/Testing/UnitTests/Services/QuizAttemptServiceAttemptHistoryTests.cs
+++ b/Testing/UnitTests/Services/QuizAttemptServiceAttemptHistoryTests.cs
@@ -1,0 +1,185 @@
+using backend.Models;
+using backend.Repositories;
+using backend.Services;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace backend.Tests.Services;
+
+public class QuizAttemptServiceAttemptHistoryTests
+{
+    private static QuizAttemptService BuildSut(
+        Mock<IQuizAttemptRepository> attemptRepository,
+        Mock<IQuizRepository> quizRepository,
+        Mock<IAlgorithmRepository> algorithmRepository)
+    {
+        var questionRepository = new Mock<IQuizQuestionRepository>();
+        var userRepository = new Mock<IUserRepository>();
+        var badgeService = new Mock<IBadgeService>();
+
+        return new QuizAttemptService(
+            quizRepository.Object,
+            questionRepository.Object,
+            userRepository.Object,
+            attemptRepository.Object,
+            algorithmRepository.Object,
+            badgeService.Object,
+            NullLogger<QuizAttemptService>.Instance);
+    }
+
+    [Fact(DisplayName = "GetUserAttemptHistoryAsync normalizes invalid pagination and returns empty page")]
+    public async Task GetUserAttemptHistoryAsync_InvalidPaging_ReturnsNormalizedEmptyResponse()
+    {
+        const int userId = 15;
+
+        var attemptRepository = new Mock<IQuizAttemptRepository>();
+        var quizRepository = new Mock<IQuizRepository>();
+        var algorithmRepository = new Mock<IAlgorithmRepository>();
+
+        attemptRepository
+            .Setup(r => r.GetAttemptsForUserAsync(userId, 1, 10))
+            .ReturnsAsync((Attempts: Enumerable.Empty<QuizAttempt>(), TotalCount: 0));
+
+        var result = await BuildSut(attemptRepository, quizRepository, algorithmRepository)
+            .GetUserAttemptHistoryAsync(userId, pageNumber: 0, pageSize: 0);
+
+        result.Page.Should().Be(1);
+        result.PageSize.Should().Be(10);
+        result.TotalAttempts.Should().Be(0);
+        result.Attempts.Should().BeEmpty();
+        result.TotalPages.Should().Be(0);
+        result.HasNextPage.Should().BeFalse();
+        result.HasPreviousPage.Should().BeFalse();
+
+        quizRepository.Verify(r => r.GetByIdsAsync(It.IsAny<IEnumerable<int>>()), Times.Never);
+        algorithmRepository.Verify(r => r.GetByIdsAsync(It.IsAny<IEnumerable<int>>()), Times.Never);
+    }
+
+    [Fact(DisplayName = "GetUserAttemptHistoryAsync caps page size at 100 and enriches attempts")]
+    public async Task GetUserAttemptHistoryAsync_PageSizeAboveCap_UsesCapAndEnrichesData()
+    {
+        const int userId = 8;
+        var now = new DateTime(2026, 4, 19, 10, 0, 0, DateTimeKind.Utc);
+
+        var attemptRepository = new Mock<IQuizAttemptRepository>();
+        var quizRepository = new Mock<IQuizRepository>();
+        var algorithmRepository = new Mock<IAlgorithmRepository>();
+
+        var attempts = new List<QuizAttempt>
+        {
+            new()
+            {
+                AttemptId = 101,
+                UserId = userId,
+                QuizId = 5,
+                Score = 78,
+                XpEarned = 40,
+                Passed = true,
+                StartedAt = now.AddMinutes(-20),
+                CompletedAt = now
+            }
+        };
+
+        attemptRepository
+            .Setup(r => r.GetAttemptsForUserAsync(userId, 2, 100))
+            .ReturnsAsync((Attempts: attempts, TotalCount: 150));
+
+        quizRepository
+            .Setup(r => r.GetByIdsAsync(It.Is<IEnumerable<int>>(ids => ids.SequenceEqual(new[] { 5 }))))
+            .ReturnsAsync(new[]
+            {
+                new Quiz { QuizId = 5, AlgorithmId = 9, Title = "Binary Search" }
+            });
+
+        algorithmRepository
+            .Setup(r => r.GetByIdsAsync(It.Is<IEnumerable<int>>(ids => ids.SequenceEqual(new[] { 9 }))))
+            .ReturnsAsync(new[]
+            {
+                new Algorithm { AlgorithmId = 9, Name = "Searching" }
+            });
+
+        var result = await BuildSut(attemptRepository, quizRepository, algorithmRepository)
+            .GetUserAttemptHistoryAsync(userId, pageNumber: 2, pageSize: 500);
+
+        result.Page.Should().Be(2);
+        result.PageSize.Should().Be(100);
+        result.TotalAttempts.Should().Be(150);
+        result.TotalPages.Should().Be(2);
+        result.HasNextPage.Should().BeFalse();
+        result.HasPreviousPage.Should().BeTrue();
+
+        var item = result.Attempts.Single();
+        item.AttemptId.Should().Be(101);
+        item.QuizTitle.Should().Be("Binary Search");
+        item.AlgorithmName.Should().Be("Searching");
+    }
+
+    [Fact(DisplayName = "GetUserAttemptHistoryAsync falls back to unknown labels when lookup data is missing")]
+    public async Task GetUserAttemptHistoryAsync_MissingLookupData_UsesUnknownFallbacks()
+    {
+        const int userId = 21;
+        var now = new DateTime(2026, 4, 19, 12, 0, 0, DateTimeKind.Utc);
+
+        var attemptRepository = new Mock<IQuizAttemptRepository>();
+        var quizRepository = new Mock<IQuizRepository>();
+        var algorithmRepository = new Mock<IAlgorithmRepository>();
+
+        var attempts = new List<QuizAttempt>
+        {
+            new()
+            {
+                AttemptId = 201,
+                UserId = userId,
+                QuizId = 10,
+                Score = 90,
+                XpEarned = 50,
+                Passed = true,
+                StartedAt = now.AddMinutes(-15),
+                CompletedAt = now.AddMinutes(-10)
+            },
+            new()
+            {
+                AttemptId = 202,
+                UserId = userId,
+                QuizId = 999,
+                Score = 40,
+                XpEarned = 0,
+                Passed = false,
+                StartedAt = now.AddMinutes(-30),
+                CompletedAt = now.AddMinutes(-25)
+            }
+        };
+
+        attemptRepository
+            .Setup(r => r.GetAttemptsForUserAsync(userId, 1, 20))
+            .ReturnsAsync((Attempts: attempts, TotalCount: 2));
+
+        quizRepository
+            .Setup(r => r.GetByIdsAsync(It.Is<IEnumerable<int>>(ids => ids.OrderBy(i => i).SequenceEqual(new[] { 10, 999 }))))
+            .ReturnsAsync(new[]
+            {
+                new Quiz { QuizId = 10, AlgorithmId = 7, Title = "Quick Sort Quiz" }
+            });
+
+        algorithmRepository
+            .Setup(r => r.GetByIdsAsync(It.Is<IEnumerable<int>>(ids => ids.SequenceEqual(new[] { 7 }))))
+            .ReturnsAsync(new[]
+            {
+                new Algorithm { AlgorithmId = 7, Name = "Quick Sort" }
+            });
+
+        var result = await BuildSut(attemptRepository, quizRepository, algorithmRepository)
+            .GetUserAttemptHistoryAsync(userId, pageNumber: 1, pageSize: 20);
+
+        var items = result.Attempts.ToList();
+        items.Select(x => x.AttemptId).Should().Equal(201, 202);
+
+        items[0].QuizTitle.Should().Be("Quick Sort Quiz");
+        items[0].AlgorithmName.Should().Be("Quick Sort");
+
+        items[1].QuizTitle.Should().Be("Unknown Quiz");
+        items[1].AlgorithmName.Should().Be("Unknown Algorithm");
+    }
+}

--- a/Testing/UnitTests/Services/QuizServiceStatsTests.cs
+++ b/Testing/UnitTests/Services/QuizServiceStatsTests.cs
@@ -1,0 +1,96 @@
+using backend.Models;
+using backend.Repositories;
+using backend.Services;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace backend.Tests.Services;
+
+public class QuizServiceStatsTests
+{
+    private static QuizService BuildSut(
+        Mock<IQuizRepository> quizRepository,
+        Mock<IQuizAttemptRepository> attemptRepository)
+    {
+        var userRepository = new Mock<IUserRepository>();
+        var algorithmRepository = new Mock<IAlgorithmRepository>();
+
+        return new QuizService(
+            quizRepository.Object,
+            userRepository.Object,
+            algorithmRepository.Object,
+            attemptRepository.Object,
+            NullLogger<QuizService>.Instance);
+    }
+
+    [Fact(DisplayName = "GetStatsAsync returns null when quiz does not exist")]
+    public async Task GetStatsAsync_QuizMissing_ReturnsNull()
+    {
+        var quizRepository = new Mock<IQuizRepository>();
+        var attemptRepository = new Mock<IQuizAttemptRepository>();
+
+        quizRepository
+            .Setup(r => r.GetByIdAsync(999))
+            .ReturnsAsync((Quiz?)null);
+
+        var result = await BuildSut(quizRepository, attemptRepository).GetStatsAsync(999);
+
+        result.Should().BeNull();
+        attemptRepository.Verify(r => r.GetAllAsync(), Times.Never);
+    }
+
+    [Fact(DisplayName = "GetStatsAsync returns zeroed stats when quiz has no attempts")]
+    public async Task GetStatsAsync_NoAttempts_ReturnsZeroStats()
+    {
+        const int quizId = 5;
+
+        var quizRepository = new Mock<IQuizRepository>();
+        var attemptRepository = new Mock<IQuizAttemptRepository>();
+
+        quizRepository
+            .Setup(r => r.GetByIdAsync(quizId))
+            .ReturnsAsync(new Quiz { QuizId = quizId, Title = "Graphs Intro" });
+
+        attemptRepository
+            .Setup(r => r.GetAllAsync())
+            .ReturnsAsync(Array.Empty<QuizAttempt>());
+
+        var result = await BuildSut(quizRepository, attemptRepository).GetStatsAsync(quizId);
+
+        result.Should().NotBeNull();
+        result!.AttemptCount.Should().Be(0);
+        result.AverageScore.Should().Be(0);
+        result.PassRate.Should().Be(0);
+    }
+
+    [Fact(DisplayName = "GetStatsAsync computes attempt count, average score, and pass rate for a quiz")]
+    public async Task GetStatsAsync_WithAttempts_ComputesFilteredStats()
+    {
+        const int quizId = 7;
+
+        var quizRepository = new Mock<IQuizRepository>();
+        var attemptRepository = new Mock<IQuizAttemptRepository>();
+
+        quizRepository
+            .Setup(r => r.GetByIdAsync(quizId))
+            .ReturnsAsync(new Quiz { QuizId = quizId, Title = "Quick Sort" });
+
+        attemptRepository
+            .Setup(r => r.GetAllAsync())
+            .ReturnsAsync(new[]
+            {
+                new QuizAttempt { AttemptId = 1, QuizId = quizId, UserId = 1, Score = 80, Passed = true },
+                new QuizAttempt { AttemptId = 2, QuizId = quizId, UserId = 2, Score = 60, Passed = false },
+                new QuizAttempt { AttemptId = 3, QuizId = 999, UserId = 3, Score = 100, Passed = true }
+            });
+
+        var result = await BuildSut(quizRepository, attemptRepository).GetStatsAsync(quizId);
+
+        result.Should().NotBeNull();
+        result!.AttemptCount.Should().Be(2);
+        result.AverageScore.Should().BeApproximately(70.0, 0.0001);
+        result.PassRate.Should().BeApproximately(50.0, 0.0001);
+    }
+}


### PR DESCRIPTION
Implemented  backend branch SA-265-Write-unit-tests-for-all-analytics-aggregation-service-methods, with no frontend changes.

What is covered:

1. Platform stats aggregation totals and pass-rate behavior, including zero-attempt edge case.
2. Leaderboard ranking behavior, including tie-aware rank assignment and attempt aggregates per user.
3. Per-quiz stats behavior for missing quiz, empty attempts, and filtered stats computation.
4. Attempt history pagination normalization, page size cap at 100, enrichment with quiz/algorithm names, and unknown fallbacks when lookup data is missing.

Validation run:

- Executed UnitTests project with filter for the three new test classes.
- Result: 9 tests run, 9 passed, 0 failed.
- Existing warnings were reported in pre-existing simulation test files, unrelated to these new tests.