### PR TITLE
Add unit tests for various services in the backend

### DIFF
--- a/Testing/UnitTests/Controllers/AdminControllerTests.cs
+++ b/Testing/UnitTests/Controllers/AdminControllerTests.cs
@@ -1,0 +1,88 @@
+using backend.Controllers;
+using backend.DTOs;
+using backend.Services;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace backend.Tests.Controllers;
+
+public class AdminControllerTests
+{
+    private static AdminController BuildController(Mock<IAdminService> service)
+    {
+        return new AdminController(service.Object, NullLogger<AdminController>.Instance)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext()
+            }
+        };
+    }
+
+    [Fact(DisplayName = "GetPlatformStats returns 200 OK with platform statistics")]
+    public async Task GetPlatformStats_Success_ReturnsOk()
+    {
+        var service = new Mock<IAdminService>();
+        service
+            .Setup(s => s.GetPlatformStatsAsync())
+            .ReturnsAsync(new AdminStatsDto
+            {
+                TotalUsers = 10,
+                TotalQuizzes = 5,
+                TotalAttempts = 40,
+                AveragePassRate = 62.5
+            });
+
+        var result = await BuildController(service).GetPlatformStats() as OkObjectResult;
+
+        result!.StatusCode.Should().Be(StatusCodes.Status200OK);
+        result.Value.Should().BeOfType<AdminStatsDto>();
+    }
+
+    [Fact(DisplayName = "GetPlatformStats returns 500 when the service throws")]
+    public async Task GetPlatformStats_ServiceThrows_ReturnsServerError()
+    {
+        var service = new Mock<IAdminService>();
+        service
+            .Setup(s => s.GetPlatformStatsAsync())
+            .ThrowsAsync(new InvalidOperationException("boom"));
+
+        var result = await BuildController(service).GetPlatformStats() as ObjectResult;
+
+        result!.StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
+    }
+
+    [Fact(DisplayName = "GetLeaderboard returns 200 OK with leaderboard entries")]
+    public async Task GetLeaderboard_Success_ReturnsOk()
+    {
+        var service = new Mock<IAdminService>();
+        service
+            .Setup(s => s.GetLeaderboardAsync())
+            .ReturnsAsync(new[]
+            {
+                new LeaderboardEntryDto { UserId = 1, Username = "alice", Rank = 1, XpTotal = 500 }
+            });
+
+        var result = await BuildController(service).GetLeaderboard() as OkObjectResult;
+
+        result!.StatusCode.Should().Be(StatusCodes.Status200OK);
+        result.Value.Should().BeAssignableTo<IEnumerable<LeaderboardEntryDto>>();
+    }
+
+    [Fact(DisplayName = "GetLeaderboard returns 500 when the service throws")]
+    public async Task GetLeaderboard_ServiceThrows_ReturnsServerError()
+    {
+        var service = new Mock<IAdminService>();
+        service
+            .Setup(s => s.GetLeaderboardAsync())
+            .ThrowsAsync(new InvalidOperationException("boom"));
+
+        var result = await BuildController(service).GetLeaderboard() as ObjectResult;
+
+        result!.StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
+    }
+}

--- a/Testing/UnitTests/Controllers/AlgorithmControllerTests.cs
+++ b/Testing/UnitTests/Controllers/AlgorithmControllerTests.cs
@@ -1,0 +1,78 @@
+using backend.Controllers;
+using backend.DTOs;
+using backend.Services;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace backend.Tests.Controllers;
+
+public class AlgorithmControllerTests
+{
+    private static AlgorithmResponseDto CreateDto(int id, string name) => new()
+    {
+        AlgorithmId = id,
+        Name = name,
+        Category = "Sorting",
+        Description = $"{name} description",
+        TimeComplexityBest = "O(n)",
+        TimeComplexityAverage = "O(n log n)",
+        TimeComplexityWorst = "O(n^2)",
+        QuizAvailable = true,
+        CreatedAt = new DateTime(2026, 4, 1, 0, 0, 0, DateTimeKind.Utc)
+    };
+
+    private static AlgorithmController BuildController(Mock<IAlgorithmService> service)
+    {
+        return new AlgorithmController(service.Object, NullLogger<AlgorithmController>.Instance)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext()
+            }
+        };
+    }
+
+    [Fact(DisplayName = "GetAllAlgorithms returns 200 OK with success wrapper")]
+    public async Task GetAllAlgorithms_Success_ReturnsOk()
+    {
+        var service = new Mock<IAlgorithmService>();
+        service
+            .Setup(s => s.GetAllAlgorithmsAsync())
+            .ReturnsAsync(new[] { CreateDto(1, "Bubble Sort"), CreateDto(2, "Heap Sort") });
+
+        var result = await BuildController(service).GetAllAlgorithms() as OkObjectResult;
+
+        result!.StatusCode.Should().Be(StatusCodes.Status200OK);
+        result.Value!.GetType().GetProperty("status")!.GetValue(result.Value).Should().Be("success");
+    }
+
+    [Fact(DisplayName = "GetAlgorithmById returns 200 OK when the algorithm exists")]
+    public async Task GetAlgorithmById_Found_ReturnsOk()
+    {
+        var service = new Mock<IAlgorithmService>();
+        service
+            .Setup(s => s.GetAlgorithmByIdAsync(4))
+            .ReturnsAsync(CreateDto(4, "Merge Sort"));
+
+        var result = await BuildController(service).GetAlgorithmById(4) as OkObjectResult;
+
+        result!.StatusCode.Should().Be(StatusCodes.Status200OK);
+    }
+
+    [Fact(DisplayName = "GetAlgorithmById returns 404 when the algorithm does not exist")]
+    public async Task GetAlgorithmById_Missing_ReturnsNotFound()
+    {
+        var service = new Mock<IAlgorithmService>();
+        service
+            .Setup(s => s.GetAlgorithmByIdAsync(99))
+            .ReturnsAsync((AlgorithmResponseDto?)null);
+
+        var result = await BuildController(service).GetAlgorithmById(99) as NotFoundObjectResult;
+
+        result!.StatusCode.Should().Be(StatusCodes.Status404NotFound);
+    }
+}

--- a/Testing/UnitTests/Controllers/BadgeControllerTests.cs
+++ b/Testing/UnitTests/Controllers/BadgeControllerTests.cs
@@ -1,0 +1,117 @@
+using backend.Controllers;
+using backend.DTOs;
+using backend.Services;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace backend.Tests.Controllers;
+
+public class BadgeControllerTests
+{
+    private static BadgeResponseDto CreateBadgeDto(int id, string name) => new()
+    {
+        BadgeId = id,
+        BadgeName = name,
+        BadgeDescription = $"{name} description",
+        XpThreshold = 100,
+        IconType = "star",
+        IconColor = "#123456",
+        UnlockHint = "Keep going"
+    };
+
+    private static BadgeController BuildController(Mock<IBadgeService> service)
+    {
+        return new BadgeController(service.Object, NullLogger<BadgeController>.Instance)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext()
+            }
+        };
+    }
+
+    [Fact(DisplayName = "GetAllBadges returns 200 OK with badge data")]
+    public async Task GetAllBadges_Success_ReturnsOk()
+    {
+        var service = new Mock<IBadgeService>();
+        service
+            .Setup(s => s.GetAllBadgesAsync())
+            .ReturnsAsync(new[] { CreateBadgeDto(1, "Bronze"), CreateBadgeDto(2, "Silver") });
+
+        var result = await BuildController(service).GetAllBadges() as OkObjectResult;
+
+        result!.StatusCode.Should().Be(StatusCodes.Status200OK);
+        result.Value.Should().BeAssignableTo<IEnumerable<BadgeResponseDto>>();
+    }
+
+    [Fact(DisplayName = "GetBadgeById returns 404 when the badge does not exist")]
+    public async Task GetBadgeById_Missing_ReturnsNotFound()
+    {
+        var service = new Mock<IBadgeService>();
+        service
+            .Setup(s => s.GetBadgeByIdAsync(99))
+            .ReturnsAsync((BadgeResponseDto?)null);
+
+        var result = await BuildController(service).GetBadgeById(99) as NotFoundObjectResult;
+
+        result!.StatusCode.Should().Be(StatusCodes.Status404NotFound);
+    }
+
+    [Fact(DisplayName = "GetUserEarnedBadges returns 200 OK with earned badges")]
+    public async Task GetUserEarnedBadges_Success_ReturnsOk()
+    {
+        var service = new Mock<IBadgeService>();
+        service
+            .Setup(s => s.GetUserEarnedBadgesAsync(5))
+            .ReturnsAsync(new[] { CreateBadgeDto(1, "Bronze") });
+
+        var result = await BuildController(service).GetUserEarnedBadges(5) as OkObjectResult;
+
+        result!.StatusCode.Should().Be(StatusCodes.Status200OK);
+    }
+
+    [Fact(DisplayName = "AwardUnlockedBadges returns 200 OK with awarded badges payload")]
+    public async Task AwardUnlockedBadges_Success_ReturnsOk()
+    {
+        var service = new Mock<IBadgeService>();
+        service
+            .Setup(s => s.AwardUnlockedBadgesAsync(5))
+            .ReturnsAsync(new[] { CreateBadgeDto(2, "Binary Search") });
+
+        var result = await BuildController(service).AwardUnlockedBadges(5) as OkObjectResult;
+
+        result!.StatusCode.Should().Be(StatusCodes.Status200OK);
+        result.Value!.GetType().GetProperty("awardedBadges")!.GetValue(result.Value)
+            .Should().BeAssignableTo<IEnumerable<BadgeResponseDto>>();
+    }
+
+    [Fact(DisplayName = "AwardBadge returns 409 Conflict when the badge cannot be awarded")]
+    public async Task AwardBadge_Failure_ReturnsConflict()
+    {
+        var service = new Mock<IBadgeService>();
+        service
+            .Setup(s => s.AwardBadgeAsync(5, 3))
+            .ReturnsAsync(false);
+
+        var result = await BuildController(service).AwardBadge(5, 3) as ConflictObjectResult;
+
+        result!.StatusCode.Should().Be(StatusCodes.Status409Conflict);
+    }
+
+    [Fact(DisplayName = "GetAllBadges returns 500 when the service throws")]
+    public async Task GetAllBadges_ServiceThrows_ReturnsServerError()
+    {
+        var service = new Mock<IBadgeService>();
+        service
+            .Setup(s => s.GetAllBadgesAsync())
+            .ThrowsAsync(new InvalidOperationException("DB unavailable"));
+
+        var result = await BuildController(service).GetAllBadges() as ObjectResult;
+
+        result!.StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
+    }
+}

--- a/Testing/UnitTests/Controllers/LeaderboardControllerTests.cs
+++ b/Testing/UnitTests/Controllers/LeaderboardControllerTests.cs
@@ -1,0 +1,106 @@
+using System.Security.Claims;
+using backend.Controllers;
+using backend.DTOs;
+using backend.Models;
+using backend.Repositories;
+using backend.Services;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace backend.Tests.Controllers;
+
+public class LeaderboardControllerTests
+{
+    private static LeaderboardController BuildController(
+        Mock<ILeaderboardService> leaderboardService,
+        Mock<IUserRepository> userRepository,
+        string? clerkUserId = "clerk_001")
+    {
+        var controller = new LeaderboardController(
+            leaderboardService.Object,
+            userRepository.Object,
+            NullLogger<LeaderboardController>.Instance);
+
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                User = clerkUserId is null
+                    ? new ClaimsPrincipal(new ClaimsIdentity())
+                    : new ClaimsPrincipal(new ClaimsIdentity([new Claim("sub", clerkUserId)], "TestAuth"))
+            }
+        };
+
+        return controller;
+    }
+
+    [Fact(DisplayName = "GetLeaderboard returns 401 when the user claim is missing")]
+    public async Task GetLeaderboard_MissingClaim_ReturnsUnauthorized()
+    {
+        var leaderboardService = new Mock<ILeaderboardService>();
+        var userRepository = new Mock<IUserRepository>();
+
+        var result = await BuildController(leaderboardService, userRepository, clerkUserId: null).GetLeaderboard() as UnauthorizedObjectResult;
+
+        result!.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
+        userRepository.Verify(r => r.GetByClerkUserIdAsync(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact(DisplayName = "GetLeaderboard returns 404 when no local user exists for the Clerk identity")]
+    public async Task GetLeaderboard_UnknownUser_ReturnsNotFound()
+    {
+        var leaderboardService = new Mock<ILeaderboardService>();
+        var userRepository = new Mock<IUserRepository>();
+        userRepository
+            .Setup(r => r.GetByClerkUserIdAsync("clerk_001"))
+            .ReturnsAsync((User?)null);
+
+        var result = await BuildController(leaderboardService, userRepository).GetLeaderboard() as NotFoundObjectResult;
+
+        result!.StatusCode.Should().Be(StatusCodes.Status404NotFound);
+    }
+
+    [Fact(DisplayName = "GetLeaderboard returns 200 OK with leaderboard data for the current user")]
+    public async Task GetLeaderboard_Success_ReturnsOk()
+    {
+        var leaderboardService = new Mock<ILeaderboardService>();
+        var userRepository = new Mock<IUserRepository>();
+
+        userRepository
+            .Setup(r => r.GetByClerkUserIdAsync("clerk_001"))
+            .ReturnsAsync(new User { UserId = 7, ClerkUserId = "clerk_001", Username = "alice" });
+        leaderboardService
+            .Setup(s => s.GetLeaderboardAsync(7, 10))
+            .ReturnsAsync(new[]
+            {
+                new LeaderboardEntryDto { UserId = 7, Username = "alice", Rank = 3, XpTotal = 250, IsCurrentUser = true }
+            });
+
+        var result = await BuildController(leaderboardService, userRepository).GetLeaderboard() as OkObjectResult;
+
+        result!.StatusCode.Should().Be(StatusCodes.Status200OK);
+        result.Value!.GetType().GetProperty("status")!.GetValue(result.Value).Should().Be("success");
+    }
+
+    [Fact(DisplayName = "GetLeaderboard returns 500 when the service throws unexpectedly")]
+    public async Task GetLeaderboard_ServiceThrows_ReturnsServerError()
+    {
+        var leaderboardService = new Mock<ILeaderboardService>();
+        var userRepository = new Mock<IUserRepository>();
+
+        userRepository
+            .Setup(r => r.GetByClerkUserIdAsync("clerk_001"))
+            .ReturnsAsync(new User { UserId = 7, ClerkUserId = "clerk_001", Username = "alice" });
+        leaderboardService
+            .Setup(s => s.GetLeaderboardAsync(7, 10))
+            .ThrowsAsync(new InvalidOperationException("boom"));
+
+        var result = await BuildController(leaderboardService, userRepository).GetLeaderboard() as ObjectResult;
+
+        result!.StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
+    }
+}

--- a/Testing/UnitTests/Controllers/StudentControllerTests.cs
+++ b/Testing/UnitTests/Controllers/StudentControllerTests.cs
@@ -1,0 +1,161 @@
+using System.Security.Claims;
+using backend.Controllers;
+using backend.DTOs;
+using backend.Models;
+using backend.Repositories;
+using backend.Services;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace backend.Tests.Controllers;
+
+public class StudentControllerTests
+{
+    private static StudentController BuildController(
+        Mock<IUserService>? userService = null,
+        Mock<IUserRepository>? userRepository = null,
+        Mock<ILevelingService>? levelingService = null,
+        Mock<IQuizAttemptService>? attemptService = null,
+        Mock<IActivityService>? activityService = null,
+        Mock<IStudentDashboardService>? dashboardService = null,
+        Mock<IActivityHeatmapService>? heatmapService = null,
+        string? clerkUserId = "clerk_001",
+        string? role = null)
+    {
+        var identity = clerkUserId is null
+            ? new ClaimsIdentity()
+            : new ClaimsIdentity(
+            [
+                new Claim("sub", clerkUserId),
+                new Claim(ClaimTypes.NameIdentifier, clerkUserId)
+            ], "TestAuth");
+
+        if (!string.IsNullOrWhiteSpace(role))
+        {
+            identity.AddClaim(new Claim(ClaimTypes.Role, role));
+        }
+
+        var controller = new StudentController(
+            (userService ?? new Mock<IUserService>()).Object,
+            (userRepository ?? new Mock<IUserRepository>()).Object,
+            (levelingService ?? new Mock<ILevelingService>()).Object,
+            (attemptService ?? new Mock<IQuizAttemptService>()).Object,
+            (activityService ?? new Mock<IActivityService>()).Object,
+            (dashboardService ?? new Mock<IStudentDashboardService>()).Object,
+            (heatmapService ?? new Mock<IActivityHeatmapService>()).Object,
+            NullLogger<StudentController>.Instance);
+
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                User = new ClaimsPrincipal(identity)
+            }
+        };
+
+        return controller;
+    }
+
+    [Fact(DisplayName = "GetStudentDashboard returns 401 when the authenticated user claim is missing")]
+    public async Task GetStudentDashboard_MissingClaim_ReturnsUnauthorized()
+    {
+        var userRepository = new Mock<IUserRepository>();
+
+        var result = await BuildController(userRepository: userRepository, clerkUserId: null).GetStudentDashboard(5) as UnauthorizedObjectResult;
+
+        result!.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
+    }
+
+    [Fact(DisplayName = "GetUserProgression returns 200 OK with derived progression data for an authorized student")]
+    public async Task GetUserProgression_AuthorizedStudent_ReturnsOk()
+    {
+        var userService = new Mock<IUserService>();
+        var userRepository = new Mock<IUserRepository>();
+        var levelingService = new Mock<ILevelingService>();
+
+        userRepository
+            .Setup(r => r.GetByClerkUserIdAsync("clerk_001"))
+            .ReturnsAsync(new User { UserId = 5, ClerkUserId = "clerk_001", Username = "alice" });
+        userService
+            .Setup(s => s.GetUserByIdAsync(5))
+            .ReturnsAsync(new UserResponseDto { UserId = 5, XpTotal = 250, Username = "alice" });
+        levelingService.Setup(s => s.CalculateLevel(250)).Returns(2);
+        levelingService.Setup(s => s.GetXpForPreviousLevel(2)).Returns(100);
+        levelingService.Setup(s => s.GetXpForNextLevel(2)).Returns(382);
+
+        var result = await BuildController(userService, userRepository, levelingService).GetUserProgression(5) as OkObjectResult;
+
+        result!.StatusCode.Should().Be(StatusCodes.Status200OK);
+
+        var data = result.Value!.GetType().GetProperty("data")!.GetValue(result.Value) as UserProgressionDto;
+        data.Should().NotBeNull();
+        data!.CurrentLevel.Should().Be(2);
+        data.XpInCurrentLevel.Should().Be(150);
+        data.XpNeededForLevel.Should().Be(282);
+        data.ProgressPercentage.Should().BeApproximately(53.19, 0.01);
+    }
+
+    [Fact(DisplayName = "GetActivityHeatmap returns 403 when a student requests another student's data")]
+    public async Task GetActivityHeatmap_DifferentStudent_ReturnsForbid()
+    {
+        var userRepository = new Mock<IUserRepository>();
+        userRepository
+            .Setup(r => r.GetByClerkUserIdAsync("clerk_001"))
+            .ReturnsAsync(new User { UserId = 5, ClerkUserId = "clerk_001" });
+
+        var result = await BuildController(userRepository: userRepository).GetActivityHeatmap(9);
+
+        result.Should().BeOfType<ForbidResult>();
+    }
+
+    [Fact(DisplayName = "GetRecentActivity returns 400 when the limit is outside the allowed range")]
+    public async Task GetRecentActivity_InvalidLimit_ReturnsBadRequest()
+    {
+        var result = await BuildController().GetRecentActivity(5, limit: 0) as BadRequestObjectResult;
+
+        result!.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    [Fact(DisplayName = "GetStudentAttemptHistory allows admin users to read any student's attempts")]
+    public async Task GetStudentAttemptHistory_AdminUser_ReturnsOk()
+    {
+        var userService = new Mock<IUserService>();
+        var attemptService = new Mock<IQuizAttemptService>();
+
+        userService
+            .Setup(s => s.GetUserByIdAsync(9))
+            .ReturnsAsync(new UserResponseDto { UserId = 9, Username = "student" });
+        attemptService
+            .Setup(s => s.GetUserAttemptHistoryAsync(9, 2, 20))
+            .ReturnsAsync(new StudentAttemptHistoryResponseDto
+            {
+                Attempts = new List<UserAttemptHistoryDto>
+                {
+                    new()
+                    {
+                        AttemptId = 12,
+                        QuizId = 4,
+                        QuizTitle = "Binary Search",
+                        AlgorithmName = "Searching",
+                        Score = 80
+                    }
+                },
+                Page = 2,
+                PageSize = 20,
+                TotalAttempts = 1
+            });
+
+        var result = await BuildController(
+            userService: userService,
+            attemptService: attemptService,
+            clerkUserId: "admin_clerk",
+            role: "Admin").GetStudentAttemptHistory(9, page: 2, pageSize: 20) as OkObjectResult;
+
+        result!.StatusCode.Should().Be(StatusCodes.Status200OK);
+        result.Value!.GetType().GetProperty("status")!.GetValue(result.Value).Should().Be("success");
+    }
+}

--- a/Testing/UnitTests/Repositories/RepositoryCoverageTests.cs
+++ b/Testing/UnitTests/Repositories/RepositoryCoverageTests.cs
@@ -1,0 +1,329 @@
+using backend.Data;
+using backend.Models;
+using backend.Repositories;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Moq;
+using Xunit;
+
+namespace UnitTests.Repositories;
+
+internal static class RepositoryTestHelpers
+{
+    public static IConfiguration FakeConfig => new ConfigurationBuilder()
+        .AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["ConnectionStrings:DefaultConnection"] = "Server=fake;Database=fake;User=fake;Password=fake;"
+        })
+        .Build();
+
+    public static Mock<DatabaseHelper> BuildFailingDbMock()
+    {
+        var dbMock = new Mock<DatabaseHelper>(FakeConfig);
+        dbMock
+            .Setup(d => d.OpenConnectionAsync())
+            .ThrowsAsync(new InvalidOperationException("Simulated DB connection failure."));
+
+        return dbMock;
+    }
+}
+
+public class QuizRepositoryTests
+{
+    private static QuizRepository BuildRepo() => new(RepositoryTestHelpers.BuildFailingDbMock().Object);
+
+    [Fact(DisplayName = "QuizRepository constructor succeeds with a valid DatabaseHelper")]
+    public void Constructor_ValidDatabaseHelper_CreatesInstance()
+    {
+        var repo = new QuizRepository(new Mock<DatabaseHelper>(RepositoryTestHelpers.FakeConfig).Object);
+
+        repo.Should().NotBeNull();
+    }
+
+    [Fact(DisplayName = "QuizRepository propagates DB failures for primary data access methods")]
+    public async Task CoreMethods_DbFailure_PropagateException()
+    {
+        var repo = BuildRepo();
+
+        await repo.Invoking(r => r.GetActiveAsync()).Should().ThrowAsync<Exception>();
+        await repo.Invoking(r => r.GetAllAsync()).Should().ThrowAsync<Exception>();
+        await repo.Invoking(r => r.GetByIdAsync(1)).Should().ThrowAsync<Exception>();
+        await repo.Invoking(r => r.GetActiveByIdAsync(1)).Should().ThrowAsync<Exception>();
+    }
+
+    [Fact(DisplayName = "QuizRepository propagates DB failures for mutating methods")]
+    public async Task MutatingMethods_DbFailure_PropagateException()
+    {
+        var repo = BuildRepo();
+        var quiz = new Quiz { QuizId = 1, AlgorithmId = 2, CreatedBy = 3, Title = "Quiz", PassScore = 70, IsActive = true };
+
+        await repo.Invoking(r => r.CreateAsync(quiz)).Should().ThrowAsync<Exception>();
+        await repo.Invoking(r => r.UpdateAsync(quiz)).Should().ThrowAsync<Exception>();
+        await repo.Invoking(r => r.DeleteAsync(1)).Should().ThrowAsync<Exception>();
+    }
+
+    [Fact(DisplayName = "QuizRepository GetByIdsAsync returns empty without touching the database when ids are empty")]
+    public async Task GetByIdsAsync_EmptyIds_ReturnsEmpty()
+    {
+        var dbMock = RepositoryTestHelpers.BuildFailingDbMock();
+        var repo = new QuizRepository(dbMock.Object);
+
+        var result = await repo.GetByIdsAsync(Array.Empty<int>());
+
+        result.Should().BeEmpty();
+        dbMock.Verify(d => d.OpenConnectionAsync(), Times.Never);
+    }
+
+    [Fact(DisplayName = "QuizRepository GetByIdsAsync propagates DB failures for non-empty ids")]
+    public async Task GetByIdsAsync_NonEmptyIds_PropagatesException()
+    {
+        var repo = BuildRepo();
+
+        await repo.Invoking(r => r.GetByIdsAsync([1, 2])).Should().ThrowAsync<Exception>();
+    }
+}
+
+public class QuizAttemptRepositoryTests
+{
+    private static QuizAttemptRepository BuildRepo() => new(RepositoryTestHelpers.BuildFailingDbMock().Object);
+
+    [Fact(DisplayName = "QuizAttemptRepository constructor succeeds with a valid DatabaseHelper")]
+    public void Constructor_ValidDatabaseHelper_CreatesInstance()
+    {
+        var repo = new QuizAttemptRepository(new Mock<DatabaseHelper>(RepositoryTestHelpers.FakeConfig).Object);
+
+        repo.Should().NotBeNull();
+    }
+
+    [Fact(DisplayName = "QuizAttemptRepository propagates DB failures for attempt write operations")]
+    public async Task WriteMethods_DbFailure_PropagateException()
+    {
+        var repo = BuildRepo();
+        var attempt = new QuizAttempt
+        {
+            UserId = 1,
+            QuizId = 2,
+            Score = 1,
+            TotalQuestions = 2,
+            XpEarned = 10,
+            Passed = true,
+            StartedAt = DateTime.UtcNow,
+            CompletedAt = DateTime.UtcNow
+        };
+        var answer = new AttemptAnswer { AttemptId = 1, QuestionId = 5, SelectedOption = "A", IsCorrect = true };
+
+        await repo.Invoking(r => r.CreateAttemptAsync(attempt)).Should().ThrowAsync<Exception>();
+        await repo.Invoking(r => r.CreateAnswerAsync(answer)).Should().ThrowAsync<Exception>();
+        await repo.Invoking(r => r.CreateAnswersAsync([answer])).Should().ThrowAsync<Exception>();
+        await repo.Invoking(r => r.SubmitAttemptTransactionalAsync(attempt, [answer], 10)).Should().ThrowAsync<Exception>();
+    }
+
+    [Fact(DisplayName = "QuizAttemptRepository CreateAnswersAsync returns empty without touching the database when there are no answers")]
+    public async Task CreateAnswersAsync_EmptyAnswers_ReturnsEmpty()
+    {
+        var dbMock = RepositoryTestHelpers.BuildFailingDbMock();
+        var repo = new QuizAttemptRepository(dbMock.Object);
+
+        var result = await repo.CreateAnswersAsync(Array.Empty<AttemptAnswer>());
+
+        result.Should().BeEmpty();
+        dbMock.Verify(d => d.OpenConnectionAsync(), Times.Never);
+    }
+
+    [Fact(DisplayName = "QuizAttemptRepository propagates DB failures for read operations")]
+    public async Task ReadMethods_DbFailure_PropagateException()
+    {
+        var repo = BuildRepo();
+
+        await repo.Invoking(r => r.HasExistingAttemptAsync(1, 2)).Should().ThrowAsync<Exception>();
+        await repo.Invoking(r => r.GetAllAsync()).Should().ThrowAsync<Exception>();
+        await repo.Invoking(r => r.GetAttemptsForUserAsync(1, 1, 10)).Should().ThrowAsync<Exception>();
+        await repo.Invoking(r => r.GetAttemptHistoryByUserIdAsync(1)).Should().ThrowAsync<Exception>();
+        await repo.Invoking(r => r.GetAlgorithmCoverageByUserIdAsync(1)).Should().ThrowAsync<Exception>();
+        await repo.Invoking(r => r.GetPerformanceSummaryByUserIdAsync(1)).Should().ThrowAsync<Exception>();
+        await repo.Invoking(r => r.GetRecentActivityAsync(1, 10)).Should().ThrowAsync<Exception>();
+        await repo.Invoking(r => r.GetDailyActivityAsync(1)).Should().ThrowAsync<Exception>();
+    }
+}
+
+public class QuizQuestionRepositoryTests
+{
+    private static QuizQuestionRepository BuildRepo() => new(RepositoryTestHelpers.BuildFailingDbMock().Object);
+
+    [Fact(DisplayName = "QuizQuestionRepository constructor succeeds with a valid DatabaseHelper")]
+    public void Constructor_ValidDatabaseHelper_CreatesInstance()
+    {
+        var repo = new QuizQuestionRepository(new Mock<DatabaseHelper>(RepositoryTestHelpers.FakeConfig).Object);
+
+        repo.Should().NotBeNull();
+    }
+
+    [Fact(DisplayName = "QuizQuestionRepository propagates DB failures for all public methods")]
+    public async Task PublicMethods_DbFailure_PropagateException()
+    {
+        var repo = BuildRepo();
+        var question = new QuizQuestion
+        {
+            QuestionId = 1,
+            QuizId = 2,
+            QuestionText = "What is O(n)?",
+            OptionA = "A",
+            OptionB = "B",
+            OptionC = "C",
+            OptionD = "D",
+            CorrectOption = "B",
+            Difficulty = "easy",
+            XpReward = 10,
+            OrderIndex = 1,
+            IsActive = true
+        };
+
+        await repo.Invoking(r => r.GetByQuizIdAsync(2)).Should().ThrowAsync<Exception>();
+        await repo.Invoking(r => r.GetByIdAsync(1)).Should().ThrowAsync<Exception>();
+        await repo.Invoking(r => r.CreateAsync(question)).Should().ThrowAsync<Exception>();
+        await repo.Invoking(r => r.UpdateAsync(question)).Should().ThrowAsync<Exception>();
+        await repo.Invoking(r => r.DeleteAsync(1)).Should().ThrowAsync<Exception>();
+    }
+}
+
+public class BadgeRepositoryTests
+{
+    private static BadgeRepository BuildRepo() => new(RepositoryTestHelpers.BuildFailingDbMock().Object);
+
+    [Fact(DisplayName = "BadgeRepository constructor succeeds with a valid DatabaseHelper")]
+    public void Constructor_ValidDatabaseHelper_CreatesInstance()
+    {
+        var repo = new BadgeRepository(new Mock<DatabaseHelper>(RepositoryTestHelpers.FakeConfig).Object);
+
+        repo.Should().NotBeNull();
+    }
+
+    [Fact(DisplayName = "BadgeRepository propagates DB failures for public methods that require a connection")]
+    public async Task PublicMethods_DbFailure_PropagateException()
+    {
+        var repo = BuildRepo();
+        var badge = new Badge
+        {
+            BadgeId = 1,
+            BadgeName = "Bronze",
+            BadgeDescription = "First milestone",
+            XpThreshold = 100,
+            IconType = "star",
+            IconColor = "#123456",
+            UnlockHint = "Keep going"
+        };
+
+        await repo.Invoking(r => r.GetAllAsync()).Should().ThrowAsync<Exception>();
+        await repo.Invoking(r => r.GetByIdAsync(1)).Should().ThrowAsync<Exception>();
+        await repo.Invoking(r => r.GetEarnedBadgesByUserIdAsync(1)).Should().ThrowAsync<Exception>();
+        await repo.Invoking(r => r.GetUnlockedBadgesByUserIdAsync(1)).Should().ThrowAsync<Exception>();
+        await repo.Invoking(r => r.CreateAsync(badge)).Should().ThrowAsync<Exception>();
+        await repo.Invoking(r => r.UpdateAsync(1, badge)).Should().ThrowAsync<Exception>();
+        await repo.Invoking(r => r.DeleteAsync(1)).Should().ThrowAsync<Exception>();
+        await repo.Invoking(r => r.AwardBadgeToUserAsync(1, 1)).Should().ThrowAsync<Exception>();
+        await repo.Invoking(r => r.GetUnlockedAlgorithmBadgesByUserIdAsync(1)).Should().ThrowAsync<Exception>();
+        await repo.Invoking(r => r.GetEarnedBadgesWithAwardDateAsync(1)).Should().ThrowAsync<Exception>();
+    }
+}
+
+public class AlgorithmRepositoryTests
+{
+    private static AlgorithmRepository BuildRepo() => new(RepositoryTestHelpers.BuildFailingDbMock().Object);
+
+    [Fact(DisplayName = "AlgorithmRepository constructor succeeds with a valid DatabaseHelper")]
+    public void Constructor_ValidDatabaseHelper_CreatesInstance()
+    {
+        var repo = new AlgorithmRepository(new Mock<DatabaseHelper>(RepositoryTestHelpers.FakeConfig).Object);
+
+        repo.Should().NotBeNull();
+    }
+
+    [Fact(DisplayName = "AlgorithmRepository propagates DB failures for standard queries")]
+    public async Task StandardQueries_DbFailure_PropagateException()
+    {
+        var repo = BuildRepo();
+
+        await repo.Invoking(r => r.GetAllAsync()).Should().ThrowAsync<Exception>();
+        await repo.Invoking(r => r.GetByIdAsync(1)).Should().ThrowAsync<Exception>();
+    }
+
+    [Fact(DisplayName = "AlgorithmRepository GetByIdsAsync returns empty without touching the database when ids are empty")]
+    public async Task GetByIdsAsync_EmptyIds_ReturnsEmpty()
+    {
+        var dbMock = RepositoryTestHelpers.BuildFailingDbMock();
+        var repo = new AlgorithmRepository(dbMock.Object);
+
+        var result = await repo.GetByIdsAsync(Array.Empty<int>());
+
+        result.Should().BeEmpty();
+        dbMock.Verify(d => d.OpenConnectionAsync(), Times.Never);
+    }
+
+    [Fact(DisplayName = "AlgorithmRepository GetByIdsAsync propagates DB failures for non-empty ids")]
+    public async Task GetByIdsAsync_NonEmptyIds_PropagatesException()
+    {
+        var repo = BuildRepo();
+
+        await repo.Invoking(r => r.GetByIdsAsync([1, 2])).Should().ThrowAsync<Exception>();
+    }
+}
+
+public class CodingQuestionRepositoryTests
+{
+    private static CodingQuestionRepository BuildRepo() => new(RepositoryTestHelpers.BuildFailingDbMock().Object);
+
+    [Fact(DisplayName = "CodingQuestionRepository constructor succeeds with a valid DatabaseHelper")]
+    public void Constructor_ValidDatabaseHelper_CreatesInstance()
+    {
+        var repo = new CodingQuestionRepository(new Mock<DatabaseHelper>(RepositoryTestHelpers.FakeConfig).Object);
+
+        repo.Should().NotBeNull();
+    }
+
+    [Fact(DisplayName = "CodingQuestionRepository propagates DB failures for all public methods")]
+    public async Task PublicMethods_DbFailure_PropagateException()
+    {
+        var repo = BuildRepo();
+        var question = new CodingQuestion
+        {
+            Id = 1,
+            Title = "Reverse String",
+            Description = "Return the reversed string",
+            InputExample = "abc",
+            ExpectedOutput = "cba",
+            Difficulty = "easy"
+        };
+
+        await repo.Invoking(r => r.GetAllAsync()).Should().ThrowAsync<Exception>();
+        await repo.Invoking(r => r.GetByIdAsync(1)).Should().ThrowAsync<Exception>();
+        await repo.Invoking(r => r.CreateAsync(question)).Should().ThrowAsync<Exception>();
+        await repo.Invoking(r => r.UpdateAsync(question)).Should().ThrowAsync<Exception>();
+        await repo.Invoking(r => r.DeleteAsync(1)).Should().ThrowAsync<Exception>();
+    }
+}
+
+public class ReportRepositoryTests
+{
+    private static ReportRepository BuildRepo() => new(RepositoryTestHelpers.BuildFailingDbMock().Object);
+
+    [Fact(DisplayName = "ReportRepository constructor succeeds with a valid DatabaseHelper")]
+    public void Constructor_ValidDatabaseHelper_CreatesInstance()
+    {
+        var repo = new ReportRepository(new Mock<DatabaseHelper>(RepositoryTestHelpers.FakeConfig).Object);
+
+        repo.Should().NotBeNull();
+    }
+
+    [Fact(DisplayName = "ReportRepository propagates DB failures for all report queries")]
+    public async Task PublicMethods_DbFailure_PropagateException()
+    {
+        var repo = BuildRepo();
+        var start = new DateTime(2026, 4, 1, 0, 0, 0, DateTimeKind.Utc);
+        var end = new DateTime(2026, 4, 19, 0, 0, 0, DateTimeKind.Utc);
+
+        await repo.Invoking(r => r.GetPerStudentReportAsync(start, end)).Should().ThrowAsync<Exception>();
+        await repo.Invoking(r => r.GetPerAlgorithmReportAsync(start, end)).Should().ThrowAsync<Exception>();
+        await repo.Invoking(r => r.GetPerQuizReportAsync(start, end)).Should().ThrowAsync<Exception>();
+        await repo.Invoking(r => r.GetSummaryStatisticsAsync(start, end)).Should().ThrowAsync<Exception>();
+    }
+}

--- a/Testing/UnitTests/Services/ActivityHeatmapServiceTests.cs
+++ b/Testing/UnitTests/Services/ActivityHeatmapServiceTests.cs
@@ -1,0 +1,32 @@
+using backend.DTOs;
+using backend.Repositories;
+using backend.Services;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace backend.Tests.Services;
+
+public class ActivityHeatmapServiceTests
+{
+    [Fact(DisplayName = "GetDailyActivityAsync delegates to the quiz attempt repository")]
+    public async Task GetDailyActivityAsync_DelegatesToRepository()
+    {
+        var repository = new Mock<IQuizAttemptRepository>();
+        repository
+            .Setup(r => r.GetDailyActivityAsync(5))
+            .ReturnsAsync(new[]
+            {
+                new ActivityHeatmapDto
+                {
+                    Date = new DateTime(2026, 4, 18, 0, 0, 0, DateTimeKind.Utc),
+                    Count = 3
+                }
+            });
+
+        var result = (await new ActivityHeatmapService(repository.Object).GetDailyActivityAsync(5)).ToList();
+
+        result.Should().HaveCount(1);
+        result[0].Count.Should().Be(3);
+    }
+}

--- a/Testing/UnitTests/Services/ActivityServiceTests.cs
+++ b/Testing/UnitTests/Services/ActivityServiceTests.cs
@@ -1,0 +1,34 @@
+using backend.DTOs;
+using backend.Repositories;
+using backend.Services;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace backend.Tests.Services;
+
+public class ActivityServiceTests
+{
+    [Fact(DisplayName = "GetRecentActivityAsync delegates to the quiz attempt repository")]
+    public async Task GetRecentActivityAsync_DelegatesToRepository()
+    {
+        var repository = new Mock<IQuizAttemptRepository>();
+        repository
+            .Setup(r => r.GetRecentActivityAsync(5, 20))
+            .ReturnsAsync(new[]
+            {
+                new ActivityItemDto
+                {
+                    Type = "quiz",
+                    Title = "Binary Search Quiz",
+                    XpEarned = 20,
+                    CreatedAt = new DateTime(2026, 4, 18, 0, 0, 0, DateTimeKind.Utc)
+                }
+            });
+
+        var result = (await new ActivityService(repository.Object).GetRecentActivityAsync(5, 20)).ToList();
+
+        result.Should().HaveCount(1);
+        result[0].Title.Should().Be("Binary Search Quiz");
+    }
+}

--- a/Testing/UnitTests/Services/AlgorithmServiceTests.cs
+++ b/Testing/UnitTests/Services/AlgorithmServiceTests.cs
@@ -1,0 +1,85 @@
+using backend.Models;
+using backend.Repositories;
+using backend.Services;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace backend.Tests.Services;
+
+public class AlgorithmServiceTests
+{
+    private static Algorithm CreateAlgorithm(int id, string name) => new()
+    {
+        AlgorithmId = id,
+        Name = name,
+        Category = "Sorting",
+        Description = $"{name} description",
+        TimeComplexityBest = "O(n)",
+        TimeComplexityAverage = "O(n log n)",
+        TimeComplexityWorst = "O(n^2)",
+        CreatedAt = new DateTime(2026, 4, 1, 0, 0, 0, DateTimeKind.Utc)
+    };
+
+    private static AlgorithmService BuildSut(Mock<IAlgorithmRepository> repository, IEnumerable<string>? readyAlgorithms = null)
+    {
+        var settings = (readyAlgorithms ?? [])
+            .Select((value, index) => new KeyValuePair<string, string?>($"Quiz:ReadyAlgorithms:{index}", value))
+            .ToList();
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(settings)
+            .Build();
+
+        return new AlgorithmService(repository.Object, NullLogger<AlgorithmService>.Instance, configuration);
+    }
+
+    [Fact(DisplayName = "GetAllAlgorithmsAsync maps algorithms and marks configured quiz-ready entries")]
+    public async Task GetAllAlgorithmsAsync_ReturnsMappedDtos()
+    {
+        var repository = new Mock<IAlgorithmRepository>();
+        repository
+            .Setup(r => r.GetAllAsync())
+            .ReturnsAsync(new[]
+            {
+                CreateAlgorithm(1, "Bubble Sort"),
+                CreateAlgorithm(2, "Merge Sort")
+            });
+
+        var result = (await BuildSut(repository, ["bubble_sort"]).GetAllAlgorithmsAsync()).ToList();
+
+        result.Should().HaveCount(2);
+        result[0].QuizAvailable.Should().BeTrue();
+        result[1].QuizAvailable.Should().BeFalse();
+    }
+
+    [Fact(DisplayName = "GetAlgorithmByIdAsync returns null when the algorithm is missing")]
+    public async Task GetAlgorithmByIdAsync_Missing_ReturnsNull()
+    {
+        var repository = new Mock<IAlgorithmRepository>();
+        repository
+            .Setup(r => r.GetByIdAsync(99))
+            .ReturnsAsync((Algorithm?)null);
+
+        var result = await BuildSut(repository).GetAlgorithmByIdAsync(99);
+
+        result.Should().BeNull();
+    }
+
+    [Fact(DisplayName = "GetAlgorithmByIdAsync maps an algorithm when found")]
+    public async Task GetAlgorithmByIdAsync_Found_ReturnsDto()
+    {
+        var repository = new Mock<IAlgorithmRepository>();
+        repository
+            .Setup(r => r.GetByIdAsync(5))
+            .ReturnsAsync(CreateAlgorithm(5, "Heap Sort"));
+
+        var result = await BuildSut(repository, ["heap_sort"]).GetAlgorithmByIdAsync(5);
+
+        result.Should().NotBeNull();
+        result!.AlgorithmId.Should().Be(5);
+        result.QuizAvailable.Should().BeTrue();
+    }
+}

--- a/Testing/UnitTests/Services/BadgeServiceTests.cs
+++ b/Testing/UnitTests/Services/BadgeServiceTests.cs
@@ -1,0 +1,207 @@
+using backend.DTOs;
+using backend.Models;
+using backend.Repositories;
+using backend.Services;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace backend.Tests.Services;
+
+public class BadgeServiceTests
+{
+    private static Badge CreateBadge(int id, string name, int xpThreshold = 0, int? algorithmId = null) => new()
+    {
+        BadgeId = id,
+        BadgeName = name,
+        BadgeDescription = $"{name} description",
+        XpThreshold = xpThreshold,
+        IconType = "star",
+        IconColor = "#123456",
+        UnlockHint = "Keep going",
+        AlgorithmId = algorithmId,
+        CreatedAt = new DateTime(2026, 4, 19, 10, 0, 0, DateTimeKind.Utc)
+    };
+
+    private static BadgeService BuildSut(Mock<IBadgeRepository> badgeRepository, Mock<IUserRepository>? userRepository = null)
+    {
+        return new BadgeService(badgeRepository.Object, (userRepository ?? new Mock<IUserRepository>()).Object);
+    }
+
+    [Fact(DisplayName = "GetAllBadgesAsync maps badge entities to response DTOs")]
+    public async Task GetAllBadgesAsync_ReturnsMappedDtos()
+    {
+        var badgeRepository = new Mock<IBadgeRepository>();
+        badgeRepository
+            .Setup(r => r.GetAllAsync())
+            .ReturnsAsync(new[]
+            {
+                CreateBadge(1, "Bronze", xpThreshold: 100),
+                CreateBadge(2, "Binary Search", algorithmId: 7)
+            });
+
+        var result = (await BuildSut(badgeRepository).GetAllBadgesAsync()).ToList();
+
+        result.Should().HaveCount(2);
+        result[0].BadgeId.Should().Be(1);
+        result[0].BadgeName.Should().Be("Bronze");
+        result[0].XpThreshold.Should().Be(100);
+        result[1].BadgeId.Should().Be(2);
+        result[1].BadgeName.Should().Be("Binary Search");
+    }
+
+    [Fact(DisplayName = "AwardUnlockedBadgesAsync returns empty when the user does not exist")]
+    public async Task AwardUnlockedBadgesAsync_UserMissing_ReturnsEmpty()
+    {
+        var badgeRepository = new Mock<IBadgeRepository>();
+        var userRepository = new Mock<IUserRepository>();
+
+        userRepository
+            .Setup(r => r.GetByIdAsync(42))
+            .ReturnsAsync((User?)null);
+
+        var result = await BuildSut(badgeRepository, userRepository).AwardUnlockedBadgesAsync(42);
+
+        result.Should().BeEmpty();
+        badgeRepository.Verify(r => r.GetUnlockedBadgesByUserIdAsync(It.IsAny<int>()), Times.Never);
+        badgeRepository.Verify(r => r.GetUnlockedAlgorithmBadgesByUserIdAsync(It.IsAny<int>()), Times.Never);
+        badgeRepository.Verify(r => r.AwardBadgeToUserAsync(It.IsAny<int>(), It.IsAny<int>()), Times.Never);
+    }
+
+    [Fact(DisplayName = "AwardUnlockedBadgesAsync awards unlocked XP and algorithm badges and skips duplicates")]
+    public async Task AwardUnlockedBadgesAsync_UserExists_AwardsOnlySuccessfulBadges()
+    {
+        const int userId = 8;
+
+        var xpBadge = CreateBadge(1, "Bronze", xpThreshold: 100);
+        var duplicateXpBadge = CreateBadge(2, "Silver", xpThreshold: 200);
+        var algorithmBadge = CreateBadge(3, "Heap Master", algorithmId: 4);
+
+        var badgeRepository = new Mock<IBadgeRepository>();
+        var userRepository = new Mock<IUserRepository>();
+
+        userRepository
+            .Setup(r => r.GetByIdAsync(userId))
+            .ReturnsAsync(new User { UserId = userId, Username = "alice" });
+
+        badgeRepository
+            .Setup(r => r.GetUnlockedBadgesByUserIdAsync(userId))
+            .ReturnsAsync(new[] { xpBadge, duplicateXpBadge });
+
+        badgeRepository
+            .Setup(r => r.GetUnlockedAlgorithmBadgesByUserIdAsync(userId))
+            .ReturnsAsync(new[] { algorithmBadge });
+
+        badgeRepository
+            .Setup(r => r.GetByIdAsync(xpBadge.BadgeId))
+            .ReturnsAsync(xpBadge);
+        badgeRepository
+            .Setup(r => r.GetByIdAsync(duplicateXpBadge.BadgeId))
+            .ReturnsAsync(duplicateXpBadge);
+        badgeRepository
+            .Setup(r => r.GetByIdAsync(algorithmBadge.BadgeId))
+            .ReturnsAsync(algorithmBadge);
+
+        badgeRepository
+            .Setup(r => r.AwardBadgeToUserAsync(userId, xpBadge.BadgeId))
+            .ReturnsAsync(true);
+        badgeRepository
+            .Setup(r => r.AwardBadgeToUserAsync(userId, duplicateXpBadge.BadgeId))
+            .ReturnsAsync(false);
+        badgeRepository
+            .Setup(r => r.AwardBadgeToUserAsync(userId, algorithmBadge.BadgeId))
+            .ReturnsAsync(true);
+
+        var result = (await BuildSut(badgeRepository, userRepository).AwardUnlockedBadgesAsync(userId)).ToList();
+
+        result.Should().HaveCount(2);
+        result.Select(b => b.BadgeId).Should().Equal(xpBadge.BadgeId, algorithmBadge.BadgeId);
+        badgeRepository.Verify(r => r.AwardBadgeToUserAsync(userId, duplicateXpBadge.BadgeId), Times.Once);
+    }
+
+    [Fact(DisplayName = "AwardBadgeAsync returns false when the user does not exist")]
+    public async Task AwardBadgeAsync_UserMissing_ReturnsFalse()
+    {
+        var badgeRepository = new Mock<IBadgeRepository>();
+        var userRepository = new Mock<IUserRepository>();
+
+        userRepository
+            .Setup(r => r.GetByIdAsync(10))
+            .ReturnsAsync((User?)null);
+
+        var result = await BuildSut(badgeRepository, userRepository).AwardBadgeAsync(10, 4);
+
+        result.Should().BeFalse();
+        badgeRepository.Verify(r => r.GetByIdAsync(It.IsAny<int>()), Times.Never);
+        badgeRepository.Verify(r => r.AwardBadgeToUserAsync(It.IsAny<int>(), It.IsAny<int>()), Times.Never);
+    }
+
+    [Fact(DisplayName = "AwardBadgeAsync returns false when the badge does not exist")]
+    public async Task AwardBadgeAsync_BadgeMissing_ReturnsFalse()
+    {
+        var badgeRepository = new Mock<IBadgeRepository>();
+        var userRepository = new Mock<IUserRepository>();
+
+        userRepository
+            .Setup(r => r.GetByIdAsync(10))
+            .ReturnsAsync(new User { UserId = 10 });
+        badgeRepository
+            .Setup(r => r.GetByIdAsync(4))
+            .ReturnsAsync((Badge?)null);
+
+        var result = await BuildSut(badgeRepository, userRepository).AwardBadgeAsync(10, 4);
+
+        result.Should().BeFalse();
+        badgeRepository.Verify(r => r.AwardBadgeToUserAsync(It.IsAny<int>(), It.IsAny<int>()), Times.Never);
+    }
+
+    [Fact(DisplayName = "AwardBadgeAsync delegates to the repository when user and badge exist")]
+    public async Task AwardBadgeAsync_ValidUserAndBadge_ReturnsRepositoryResult()
+    {
+        var badge = CreateBadge(4, "Binary Search");
+        var badgeRepository = new Mock<IBadgeRepository>();
+        var userRepository = new Mock<IUserRepository>();
+
+        userRepository
+            .Setup(r => r.GetByIdAsync(10))
+            .ReturnsAsync(new User { UserId = 10 });
+        badgeRepository
+            .Setup(r => r.GetByIdAsync(4))
+            .ReturnsAsync(badge);
+        badgeRepository
+            .Setup(r => r.AwardBadgeToUserAsync(10, 4))
+            .ReturnsAsync(true);
+
+        var result = await BuildSut(badgeRepository, userRepository).AwardBadgeAsync(10, 4);
+
+        result.Should().BeTrue();
+        badgeRepository.Verify(r => r.AwardBadgeToUserAsync(10, 4), Times.Once);
+    }
+
+    [Fact(DisplayName = "GetEarnedBadgesWithAwardDateAsync maps award metadata for dashboard consumption")]
+    public async Task GetEarnedBadgesWithAwardDateAsync_ReturnsMappedDtos()
+    {
+        var awardedAt = new DateTime(2026, 4, 18, 8, 30, 0, DateTimeKind.Utc);
+        var badgeRepository = new Mock<IBadgeRepository>();
+
+        badgeRepository
+            .Setup(r => r.GetEarnedBadgesWithAwardDateAsync(3))
+            .ReturnsAsync(new List<(Badge Badge, DateTime AwardedAt)>
+            {
+                (CreateBadge(5, "Bronze", xpThreshold: 100), awardedAt)
+            });
+
+        var result = (await BuildSut(badgeRepository).GetEarnedBadgesWithAwardDateAsync(3)).Single();
+
+        result.Should().BeEquivalentTo(new EarnedBadgeDto
+        {
+            Id = 5,
+            Name = "Bronze",
+            Description = "Bronze description",
+            XpThreshold = 100,
+            IconType = "star",
+            IconColor = "#123456",
+            AwardDate = awardedAt
+        });
+    }
+}

--- a/Testing/UnitTests/Services/LeaderboardServiceTests.cs
+++ b/Testing/UnitTests/Services/LeaderboardServiceTests.cs
@@ -1,0 +1,86 @@
+using backend.DTOs;
+using backend.Models;
+using backend.Repositories;
+using backend.Services;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace backend.Tests.Services;
+
+public class LeaderboardServiceTests
+{
+    [Fact(DisplayName = "GetLeaderboardAsync marks the current user when they are already in the top list")]
+    public async Task GetLeaderboardAsync_CurrentUserAlreadyInTop_MarksEntry()
+    {
+        var userRepository = new Mock<IUserRepository>();
+        userRepository
+            .Setup(r => r.GetTopUsersAsync(10))
+            .ReturnsAsync(new List<LeaderboardEntryDto>
+            {
+                new() { UserId = 1, Username = "alice", Rank = 1, XpTotal = 400 },
+                new() { UserId = 2, Username = "bob", Rank = 2, XpTotal = 350 }
+            });
+        userRepository
+            .Setup(r => r.GetUserRankAsync(2))
+            .ReturnsAsync(2);
+
+        var result = (await new LeaderboardService(userRepository.Object).GetLeaderboardAsync(2)).ToList();
+
+        result.Should().HaveCount(2);
+        result.Single(entry => entry.UserId == 2).IsCurrentUser.Should().BeTrue();
+        userRepository.Verify(r => r.GetByIdAsync(It.IsAny<int>()), Times.Never);
+    }
+
+    [Fact(DisplayName = "GetLeaderboardAsync appends the current user when they are outside the top list")]
+    public async Task GetLeaderboardAsync_CurrentUserOutsideTop_AppendsProfile()
+    {
+        var userRepository = new Mock<IUserRepository>();
+        userRepository
+            .Setup(r => r.GetTopUsersAsync(10))
+            .ReturnsAsync(new List<LeaderboardEntryDto>
+            {
+                new() { UserId = 1, Username = "alice", Rank = 1, XpTotal = 400 }
+            });
+        userRepository
+            .Setup(r => r.GetUserRankAsync(7))
+            .ReturnsAsync(17);
+        userRepository
+            .Setup(r => r.GetByIdAsync(7))
+            .ReturnsAsync(new User { UserId = 7, Username = "zoe", XpTotal = 99 });
+
+        var result = (await new LeaderboardService(userRepository.Object).GetLeaderboardAsync(7)).ToList();
+
+        result.Should().HaveCount(2);
+        result.Last().Should().BeEquivalentTo(new LeaderboardEntryDto
+        {
+            UserId = 7,
+            Username = "zoe",
+            XpTotal = 99,
+            Rank = 17,
+            IsCurrentUser = true
+        });
+    }
+
+    [Fact(DisplayName = "GetLeaderboardAsync leaves the list unchanged when the current user profile is unavailable")]
+    public async Task GetLeaderboardAsync_CurrentUserMissing_DoesNotAppend()
+    {
+        var userRepository = new Mock<IUserRepository>();
+        userRepository
+            .Setup(r => r.GetTopUsersAsync(10))
+            .ReturnsAsync(new List<LeaderboardEntryDto>
+            {
+                new() { UserId = 1, Username = "alice", Rank = 1, XpTotal = 400 }
+            });
+        userRepository
+            .Setup(r => r.GetUserRankAsync(7))
+            .ReturnsAsync(17);
+        userRepository
+            .Setup(r => r.GetByIdAsync(7))
+            .ReturnsAsync((User?)null);
+
+        var result = (await new LeaderboardService(userRepository.Object).GetLeaderboardAsync(7)).ToList();
+
+        result.Should().HaveCount(1);
+    }
+}

--- a/Testing/UnitTests/Services/LevelingServiceTests.cs
+++ b/Testing/UnitTests/Services/LevelingServiceTests.cs
@@ -1,0 +1,53 @@
+using backend.Services;
+using FluentAssertions;
+using Xunit;
+
+namespace backend.Tests.Services;
+
+public class LevelingServiceTests
+{
+    private readonly LevelingService _sut = new();
+
+    [Theory(DisplayName = "CalculateLevel returns the expected level around XP thresholds")]
+    [InlineData(0, 1)]
+    [InlineData(99, 1)]
+    [InlineData(100, 2)]
+    [InlineData(381, 2)]
+    [InlineData(382, 3)]
+    [InlineData(900, 3)]
+    [InlineData(901, 4)]
+    public void CalculateLevel_ThresholdBoundaries_ReturnsExpectedLevel(int xpTotal, int expectedLevel)
+    {
+        var result = _sut.CalculateLevel(xpTotal);
+
+        result.Should().Be(expectedLevel);
+    }
+
+    [Theory(DisplayName = "GetXpThresholdForLevel returns cumulative XP at the start of each level")]
+    [InlineData(1, 0)]
+    [InlineData(2, 100)]
+    [InlineData(3, 382)]
+    [InlineData(4, 901)]
+    public void GetXpThresholdForLevel_ReturnsExpectedThreshold(int level, int expectedThreshold)
+    {
+        var result = _sut.GetXpThresholdForLevel(level);
+
+        result.Should().Be(expectedThreshold);
+    }
+
+    [Fact(DisplayName = "GetXpThresholdForLevel returns zero for invalid levels")]
+    public void GetXpThresholdForLevel_LevelBelowOne_ReturnsZero()
+    {
+        _sut.GetXpThresholdForLevel(0).Should().Be(0);
+    }
+
+    [Theory(DisplayName = "Previous and next level helpers reuse the same progression thresholds")]
+    [InlineData(1, 0, 100)]
+    [InlineData(2, 100, 382)]
+    [InlineData(3, 382, 901)]
+    public void PreviousAndNextLevelHelpers_ReturnExpectedThresholds(int currentLevel, int expectedPrevious, int expectedNext)
+    {
+        _sut.GetXpForPreviousLevel(currentLevel).Should().Be(expectedPrevious);
+        _sut.GetXpForNextLevel(currentLevel).Should().Be(expectedNext);
+    }
+}

--- a/Testing/UnitTests/Services/QuizAttemptServiceSubmitAttemptTests.cs
+++ b/Testing/UnitTests/Services/QuizAttemptServiceSubmitAttemptTests.cs
@@ -1,0 +1,369 @@
+using backend.DTOs;
+using backend.Models;
+using backend.Repositories;
+using backend.Services;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace backend.Tests.Services;
+
+public class QuizAttemptServiceSubmitAttemptTests
+{
+    private static Quiz CreateQuiz(int quizId = 5, int passScore = 70) => new()
+    {
+        QuizId = quizId,
+        AlgorithmId = 3,
+        CreatedBy = 99,
+        Title = "Binary Search Basics",
+        PassScore = passScore,
+        IsActive = true,
+        CreatedAt = new DateTime(2026, 4, 1, 0, 0, 0, DateTimeKind.Utc),
+        UpdatedAt = new DateTime(2026, 4, 1, 0, 0, 0, DateTimeKind.Utc)
+    };
+
+    private static QuizQuestion CreateQuestion(int questionId, string correctOption, int xpReward, string explanation = "Because") => new()
+    {
+        QuestionId = questionId,
+        QuizId = 5,
+        QuestionText = $"Question {questionId}",
+        OptionA = "A",
+        OptionB = "B",
+        OptionC = "C",
+        OptionD = "D",
+        CorrectOption = correctOption,
+        Difficulty = "easy",
+        XpReward = xpReward,
+        Explanation = explanation,
+        OrderIndex = questionId,
+        CreatedAt = new DateTime(2026, 4, 1, 0, 0, 0, DateTimeKind.Utc)
+    };
+
+    private static QuizAttemptService BuildSut(
+        Mock<IQuizRepository> quizRepository,
+        Mock<IQuizQuestionRepository> questionRepository,
+        Mock<IUserRepository> userRepository,
+        Mock<IQuizAttemptRepository> attemptRepository,
+        Mock<IBadgeService> badgeService)
+    {
+        var algorithmRepository = new Mock<IAlgorithmRepository>();
+
+        return new QuizAttemptService(
+            quizRepository.Object,
+            questionRepository.Object,
+            userRepository.Object,
+            attemptRepository.Object,
+            algorithmRepository.Object,
+            badgeService.Object,
+            NullLogger<QuizAttemptService>.Instance);
+    }
+
+    [Fact(DisplayName = "SubmitAttemptAsync throws when the active quiz cannot be found")]
+    public async Task SubmitAttemptAsync_QuizMissing_ThrowsKeyNotFoundException()
+    {
+        var quizRepository = new Mock<IQuizRepository>();
+        var questionRepository = new Mock<IQuizQuestionRepository>();
+        var userRepository = new Mock<IUserRepository>();
+        var attemptRepository = new Mock<IQuizAttemptRepository>();
+        var badgeService = new Mock<IBadgeService>();
+
+        quizRepository
+            .Setup(r => r.GetActiveByIdAsync(5))
+            .ReturnsAsync((Quiz?)null);
+
+        var action = () => BuildSut(quizRepository, questionRepository, userRepository, attemptRepository, badgeService)
+            .SubmitAttemptAsync(5, "clerk_001", new CreateQuizAttemptDto());
+
+        await action.Should()
+            .ThrowAsync<KeyNotFoundException>()
+            .WithMessage("Quiz with ID 5 does not exist.");
+
+        userRepository.Verify(r => r.GetByClerkUserIdAsync(It.IsAny<string>()), Times.Never);
+        attemptRepository.Verify(r => r.SubmitAttemptTransactionalAsync(It.IsAny<QuizAttempt>(), It.IsAny<IEnumerable<AttemptAnswer>>(), It.IsAny<int>()), Times.Never);
+    }
+
+    [Fact(DisplayName = "SubmitAttemptAsync throws when the authenticated user is not synced locally")]
+    public async Task SubmitAttemptAsync_UserMissing_ThrowsKeyNotFoundException()
+    {
+        var quizRepository = new Mock<IQuizRepository>();
+        var questionRepository = new Mock<IQuizQuestionRepository>();
+        var userRepository = new Mock<IUserRepository>();
+        var attemptRepository = new Mock<IQuizAttemptRepository>();
+        var badgeService = new Mock<IBadgeService>();
+
+        quizRepository
+            .Setup(r => r.GetActiveByIdAsync(5))
+            .ReturnsAsync(CreateQuiz());
+        userRepository
+            .Setup(r => r.GetByClerkUserIdAsync("clerk_001"))
+            .ReturnsAsync((User?)null);
+
+        var action = () => BuildSut(quizRepository, questionRepository, userRepository, attemptRepository, badgeService)
+            .SubmitAttemptAsync(5, "clerk_001", new CreateQuizAttemptDto());
+
+        await action.Should()
+            .ThrowAsync<KeyNotFoundException>()
+            .WithMessage("*local account*");
+
+        questionRepository.Verify(r => r.GetByQuizIdAsync(It.IsAny<int>()), Times.Never);
+    }
+
+    [Fact(DisplayName = "SubmitAttemptAsync throws when a quiz has no active questions")]
+    public async Task SubmitAttemptAsync_NoQuestions_ThrowsArgumentException()
+    {
+        var quizRepository = new Mock<IQuizRepository>();
+        var questionRepository = new Mock<IQuizQuestionRepository>();
+        var userRepository = new Mock<IUserRepository>();
+        var attemptRepository = new Mock<IQuizAttemptRepository>();
+        var badgeService = new Mock<IBadgeService>();
+
+        quizRepository.Setup(r => r.GetActiveByIdAsync(5)).ReturnsAsync(CreateQuiz());
+        userRepository.Setup(r => r.GetByClerkUserIdAsync("clerk_001")).ReturnsAsync(new User { UserId = 15 });
+        questionRepository.Setup(r => r.GetByQuizIdAsync(5)).ReturnsAsync(Array.Empty<QuizQuestion>());
+
+        var action = () => BuildSut(quizRepository, questionRepository, userRepository, attemptRepository, badgeService)
+            .SubmitAttemptAsync(5, "clerk_001", new CreateQuizAttemptDto());
+
+        await action.Should()
+            .ThrowAsync<ArgumentException>()
+            .WithMessage("This quiz does not contain any active questions.");
+    }
+
+    [Fact(DisplayName = "SubmitAttemptAsync throws when the submission omits required answers")]
+    public async Task SubmitAttemptAsync_AnswerCountMismatch_ThrowsArgumentException()
+    {
+        var quizRepository = new Mock<IQuizRepository>();
+        var questionRepository = new Mock<IQuizQuestionRepository>();
+        var userRepository = new Mock<IUserRepository>();
+        var attemptRepository = new Mock<IQuizAttemptRepository>();
+        var badgeService = new Mock<IBadgeService>();
+
+        quizRepository.Setup(r => r.GetActiveByIdAsync(5)).ReturnsAsync(CreateQuiz());
+        userRepository.Setup(r => r.GetByClerkUserIdAsync("clerk_001")).ReturnsAsync(new User { UserId = 15 });
+        questionRepository.Setup(r => r.GetByQuizIdAsync(5)).ReturnsAsync(new[]
+        {
+            CreateQuestion(1, "A", 10),
+            CreateQuestion(2, "B", 15)
+        });
+
+        var dto = new CreateQuizAttemptDto
+        {
+            Answers = new List<QuizAttemptAnswerSubmissionDto>
+            {
+                new() { QuestionId = 1, SelectedOption = "A" }
+            }
+        };
+
+        var action = () => BuildSut(quizRepository, questionRepository, userRepository, attemptRepository, badgeService)
+            .SubmitAttemptAsync(5, "clerk_001", dto);
+
+        await action.Should()
+            .ThrowAsync<ArgumentException>()
+            .WithMessage("Exactly 2 answers are required for quiz 5.");
+    }
+
+    [Fact(DisplayName = "SubmitAttemptAsync throws when a question is answered more than once")]
+    public async Task SubmitAttemptAsync_DuplicateQuestionIds_ThrowsArgumentException()
+    {
+        var quizRepository = new Mock<IQuizRepository>();
+        var questionRepository = new Mock<IQuizQuestionRepository>();
+        var userRepository = new Mock<IUserRepository>();
+        var attemptRepository = new Mock<IQuizAttemptRepository>();
+        var badgeService = new Mock<IBadgeService>();
+
+        quizRepository.Setup(r => r.GetActiveByIdAsync(5)).ReturnsAsync(CreateQuiz());
+        userRepository.Setup(r => r.GetByClerkUserIdAsync("clerk_001")).ReturnsAsync(new User { UserId = 15 });
+        questionRepository.Setup(r => r.GetByQuizIdAsync(5)).ReturnsAsync(new[]
+        {
+            CreateQuestion(1, "A", 10),
+            CreateQuestion(2, "B", 15)
+        });
+
+        var dto = new CreateQuizAttemptDto
+        {
+            Answers = new List<QuizAttemptAnswerSubmissionDto>
+            {
+                new() { QuestionId = 1, SelectedOption = "A" },
+                new() { QuestionId = 1, SelectedOption = "B" }
+            }
+        };
+
+        var action = () => BuildSut(quizRepository, questionRepository, userRepository, attemptRepository, badgeService)
+            .SubmitAttemptAsync(5, "clerk_001", dto);
+
+        await action.Should()
+            .ThrowAsync<ArgumentException>()
+            .WithMessage("Each question may only be answered once per attempt.");
+    }
+
+    [Fact(DisplayName = "SubmitAttemptAsync throws when answers include a question from another quiz")]
+    public async Task SubmitAttemptAsync_InvalidQuestionIds_ThrowsArgumentException()
+    {
+        var quizRepository = new Mock<IQuizRepository>();
+        var questionRepository = new Mock<IQuizQuestionRepository>();
+        var userRepository = new Mock<IUserRepository>();
+        var attemptRepository = new Mock<IQuizAttemptRepository>();
+        var badgeService = new Mock<IBadgeService>();
+
+        quizRepository.Setup(r => r.GetActiveByIdAsync(5)).ReturnsAsync(CreateQuiz());
+        userRepository.Setup(r => r.GetByClerkUserIdAsync("clerk_001")).ReturnsAsync(new User { UserId = 15 });
+        questionRepository.Setup(r => r.GetByQuizIdAsync(5)).ReturnsAsync(new[]
+        {
+            CreateQuestion(1, "A", 10),
+            CreateQuestion(2, "B", 15)
+        });
+
+        var dto = new CreateQuizAttemptDto
+        {
+            Answers = new List<QuizAttemptAnswerSubmissionDto>
+            {
+                new() { QuestionId = 1, SelectedOption = "A" },
+                new() { QuestionId = 99, SelectedOption = "B" }
+            }
+        };
+
+        var action = () => BuildSut(quizRepository, questionRepository, userRepository, attemptRepository, badgeService)
+            .SubmitAttemptAsync(5, "clerk_001", dto);
+
+        await action.Should()
+            .ThrowAsync<ArgumentException>()
+            .WithMessage("One or more submitted questions do not belong to quiz 5.");
+    }
+
+    [Fact(DisplayName = "SubmitAttemptAsync grades the first attempt, awards XP, and unlocks badges")]
+    public async Task SubmitAttemptAsync_FirstAttempt_AwardsXpAndBadges()
+    {
+        const int quizId = 5;
+        const int userId = 15;
+
+        var quizRepository = new Mock<IQuizRepository>();
+        var questionRepository = new Mock<IQuizQuestionRepository>();
+        var userRepository = new Mock<IUserRepository>();
+        var attemptRepository = new Mock<IQuizAttemptRepository>();
+        var badgeService = new Mock<IBadgeService>();
+
+        QuizAttempt? persistedAttempt = null;
+        List<AttemptAnswer>? persistedAnswers = null;
+        int persistedXpAward = -1;
+
+        quizRepository.Setup(r => r.GetActiveByIdAsync(quizId)).ReturnsAsync(CreateQuiz(quizId, passScore: 70));
+        userRepository.Setup(r => r.GetByClerkUserIdAsync("clerk_001")).ReturnsAsync(new User { UserId = userId, ClerkUserId = "clerk_001" });
+        questionRepository.Setup(r => r.GetByQuizIdAsync(quizId)).ReturnsAsync(new[]
+        {
+            CreateQuestion(1, "A", 10, "A explanation"),
+            CreateQuestion(2, "B", 15, "B explanation")
+        });
+        attemptRepository.Setup(r => r.HasExistingAttemptAsync(userId, quizId)).ReturnsAsync(false);
+        attemptRepository
+            .Setup(r => r.SubmitAttemptTransactionalAsync(It.IsAny<QuizAttempt>(), It.IsAny<IEnumerable<AttemptAnswer>>(), It.IsAny<int>()))
+            .Callback<QuizAttempt, IEnumerable<AttemptAnswer>, int>((attempt, answers, xpToAward) =>
+            {
+                persistedAttempt = attempt;
+                persistedAnswers = answers.ToList();
+                persistedXpAward = xpToAward;
+            })
+            .ReturnsAsync((QuizAttempt attempt, IEnumerable<AttemptAnswer> _, int _) =>
+            {
+                attempt.AttemptId = 501;
+                return attempt;
+            });
+        badgeService
+            .Setup(s => s.AwardUnlockedBadgesAsync(userId))
+            .ReturnsAsync(Array.Empty<BadgeResponseDto>());
+
+        var dto = new CreateQuizAttemptDto
+        {
+            Answers = new List<QuizAttemptAnswerSubmissionDto>
+            {
+                new() { QuestionId = 1, SelectedOption = "a" },
+                new() { QuestionId = 2, SelectedOption = "B" }
+            }
+        };
+
+        var result = await BuildSut(quizRepository, questionRepository, userRepository, attemptRepository, badgeService)
+            .SubmitAttemptAsync(quizId, "clerk_001", dto);
+
+        result.AttemptId.Should().Be(501);
+        result.QuizId.Should().Be(quizId);
+        result.Score.Should().Be(100);
+        result.CorrectCount.Should().Be(2);
+        result.TotalQuestions.Should().Be(2);
+        result.Passed.Should().BeTrue();
+        result.XpEarned.Should().Be(25);
+        result.IsFirstAttempt.Should().BeTrue();
+        result.Results.Should().HaveCount(2);
+        result.Results.Select(r => r.IsCorrect).Should().OnlyContain(isCorrect => isCorrect);
+
+        persistedAttempt.Should().NotBeNull();
+        persistedAttempt!.UserId.Should().Be(userId);
+        persistedAttempt.QuizId.Should().Be(quizId);
+        persistedAttempt.Score.Should().Be(2);
+        persistedAttempt.TotalQuestions.Should().Be(2);
+        persistedAttempt.XpEarned.Should().Be(25);
+        persistedAttempt.Passed.Should().BeTrue();
+
+        persistedAnswers.Should().NotBeNull();
+        persistedAnswers!.Should().HaveCount(2);
+        persistedAnswers.Select(a => a.QuestionId).Should().Equal(1, 2);
+        persistedAnswers.Select(a => a.IsCorrect).Should().OnlyContain(isCorrect => isCorrect);
+
+        persistedXpAward.Should().Be(25);
+        badgeService.Verify(s => s.AwardUnlockedBadgesAsync(userId), Times.Once);
+    }
+
+    [Fact(DisplayName = "SubmitAttemptAsync gives retry attempts a score without awarding extra XP or badges")]
+    public async Task SubmitAttemptAsync_RetryAttempt_SkipsXpAndBadgeAward()
+    {
+        const int quizId = 5;
+        const int userId = 15;
+
+        var quizRepository = new Mock<IQuizRepository>();
+        var questionRepository = new Mock<IQuizQuestionRepository>();
+        var userRepository = new Mock<IUserRepository>();
+        var attemptRepository = new Mock<IQuizAttemptRepository>();
+        var badgeService = new Mock<IBadgeService>();
+
+        int persistedXpAward = -1;
+
+        quizRepository.Setup(r => r.GetActiveByIdAsync(quizId)).ReturnsAsync(CreateQuiz(quizId, passScore: 80));
+        userRepository.Setup(r => r.GetByClerkUserIdAsync("clerk_001")).ReturnsAsync(new User { UserId = userId, ClerkUserId = "clerk_001" });
+        questionRepository.Setup(r => r.GetByQuizIdAsync(quizId)).ReturnsAsync(new[]
+        {
+            CreateQuestion(1, "A", 10),
+            CreateQuestion(2, "B", 15)
+        });
+        attemptRepository.Setup(r => r.HasExistingAttemptAsync(userId, quizId)).ReturnsAsync(true);
+        attemptRepository
+            .Setup(r => r.SubmitAttemptTransactionalAsync(It.IsAny<QuizAttempt>(), It.IsAny<IEnumerable<AttemptAnswer>>(), It.IsAny<int>()))
+            .Callback<QuizAttempt, IEnumerable<AttemptAnswer>, int>((_, _, xpToAward) => persistedXpAward = xpToAward)
+            .ReturnsAsync((QuizAttempt attempt, IEnumerable<AttemptAnswer> _, int _) =>
+            {
+                attempt.AttemptId = 777;
+                return attempt;
+            });
+
+        var dto = new CreateQuizAttemptDto
+        {
+            Answers = new List<QuizAttemptAnswerSubmissionDto>
+            {
+                new() { QuestionId = 1, SelectedOption = "A" },
+                new() { QuestionId = 2, SelectedOption = "C" }
+            }
+        };
+
+        var result = await BuildSut(quizRepository, questionRepository, userRepository, attemptRepository, badgeService)
+            .SubmitAttemptAsync(quizId, "clerk_001", dto);
+
+        result.AttemptId.Should().Be(777);
+        result.Score.Should().Be(50);
+        result.CorrectCount.Should().Be(1);
+        result.TotalQuestions.Should().Be(2);
+        result.Passed.Should().BeFalse();
+        result.XpEarned.Should().Be(0);
+        result.IsFirstAttempt.Should().BeFalse();
+        persistedXpAward.Should().Be(0);
+
+        badgeService.Verify(s => s.AwardUnlockedBadgesAsync(It.IsAny<int>()), Times.Never);
+    }
+}

--- a/Testing/UnitTests/Services/QuizServiceCrudTests.cs
+++ b/Testing/UnitTests/Services/QuizServiceCrudTests.cs
@@ -1,0 +1,214 @@
+using backend.DTOs;
+using backend.Models;
+using backend.Repositories;
+using backend.Services;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace backend.Tests.Services;
+
+public class QuizServiceCrudTests
+{
+    private static Quiz CreateQuiz(int quizId = 3) => new()
+    {
+        QuizId = quizId,
+        AlgorithmId = 7,
+        CreatedBy = 10,
+        Title = "Heap Sort Quiz",
+        Description = "desc",
+        TimeLimitMins = 15,
+        PassScore = 70,
+        IsActive = true,
+        CreatedAt = new DateTime(2026, 4, 1, 0, 0, 0, DateTimeKind.Utc),
+        UpdatedAt = new DateTime(2026, 4, 2, 0, 0, 0, DateTimeKind.Utc)
+    };
+
+    private static QuizService BuildSut(
+        Mock<IQuizRepository> quizRepository,
+        Mock<IUserRepository>? userRepository = null,
+        Mock<IAlgorithmRepository>? algorithmRepository = null,
+        Mock<IQuizAttemptRepository>? attemptRepository = null)
+    {
+        return new QuizService(
+            quizRepository.Object,
+            (userRepository ?? new Mock<IUserRepository>()).Object,
+            (algorithmRepository ?? new Mock<IAlgorithmRepository>()).Object,
+            (attemptRepository ?? new Mock<IQuizAttemptRepository>()).Object,
+            NullLogger<QuizService>.Instance);
+    }
+
+    [Fact(DisplayName = "GetActiveQuizzesAsync maps active quizzes to DTOs")]
+    public async Task GetActiveQuizzesAsync_ReturnsMappedDtos()
+    {
+        var quizRepository = new Mock<IQuizRepository>();
+        quizRepository
+            .Setup(r => r.GetActiveAsync())
+            .ReturnsAsync(new[] { CreateQuiz(1), CreateQuiz(2) });
+
+        var result = (await BuildSut(quizRepository).GetActiveQuizzesAsync()).ToList();
+
+        result.Should().HaveCount(2);
+        result.Select(q => q.QuizId).Should().Equal(1, 2);
+    }
+
+    [Fact(DisplayName = "GetActiveQuizByIdAsync returns null when the quiz is inactive or missing")]
+    public async Task GetActiveQuizByIdAsync_Missing_ReturnsNull()
+    {
+        var quizRepository = new Mock<IQuizRepository>();
+        quizRepository
+            .Setup(r => r.GetActiveByIdAsync(99))
+            .ReturnsAsync((Quiz?)null);
+
+        var result = await BuildSut(quizRepository).GetActiveQuizByIdAsync(99);
+
+        result.Should().BeNull();
+    }
+
+    [Fact(DisplayName = "CreateQuizAsync throws when the creator has not been synced locally")]
+    public async Task CreateQuizAsync_CreatorMissing_ThrowsKeyNotFoundException()
+    {
+        var quizRepository = new Mock<IQuizRepository>();
+        var userRepository = new Mock<IUserRepository>();
+        var algorithmRepository = new Mock<IAlgorithmRepository>();
+
+        userRepository
+            .Setup(r => r.GetByClerkUserIdAsync("clerk_001"))
+            .ReturnsAsync((User?)null);
+
+        var dto = new CreateQuizDto { AlgorithmId = 7, Title = "New Quiz" };
+
+        var action = () => BuildSut(quizRepository, userRepository, algorithmRepository)
+            .CreateQuizAsync(dto, "clerk_001");
+
+        await action.Should()
+            .ThrowAsync<KeyNotFoundException>()
+            .WithMessage("*local account*");
+    }
+
+    [Fact(DisplayName = "CreateQuizAsync throws when the referenced algorithm does not exist")]
+    public async Task CreateQuizAsync_AlgorithmMissing_ThrowsArgumentException()
+    {
+        var quizRepository = new Mock<IQuizRepository>();
+        var userRepository = new Mock<IUserRepository>();
+        var algorithmRepository = new Mock<IAlgorithmRepository>();
+
+        userRepository
+            .Setup(r => r.GetByClerkUserIdAsync("clerk_001"))
+            .ReturnsAsync(new User { UserId = 10, ClerkUserId = "clerk_001" });
+        algorithmRepository
+            .Setup(r => r.GetByIdAsync(7))
+            .ReturnsAsync((Algorithm?)null);
+
+        var dto = new CreateQuizDto { AlgorithmId = 7, Title = "New Quiz" };
+
+        var action = () => BuildSut(quizRepository, userRepository, algorithmRepository)
+            .CreateQuizAsync(dto, "clerk_001");
+
+        await action.Should()
+            .ThrowAsync<ArgumentException>()
+            .WithMessage("Algorithm with ID 7 does not exist.");
+    }
+
+    [Fact(DisplayName = "CreateQuizAsync persists a new active quiz when inputs are valid")]
+    public async Task CreateQuizAsync_ValidInput_CreatesQuiz()
+    {
+        var quizRepository = new Mock<IQuizRepository>();
+        var userRepository = new Mock<IUserRepository>();
+        var algorithmRepository = new Mock<IAlgorithmRepository>();
+
+        userRepository
+            .Setup(r => r.GetByClerkUserIdAsync("clerk_001"))
+            .ReturnsAsync(new User { UserId = 10, ClerkUserId = "clerk_001" });
+        algorithmRepository
+            .Setup(r => r.GetByIdAsync(7))
+            .ReturnsAsync(new Algorithm { AlgorithmId = 7, Name = "Heap Sort" });
+        quizRepository
+            .Setup(r => r.CreateAsync(It.IsAny<Quiz>()))
+            .ReturnsAsync((Quiz quiz) =>
+            {
+                quiz.QuizId = 22;
+                quiz.CreatedAt = new DateTime(2026, 4, 10, 0, 0, 0, DateTimeKind.Utc);
+                quiz.UpdatedAt = new DateTime(2026, 4, 10, 0, 0, 0, DateTimeKind.Utc);
+                return quiz;
+            });
+
+        var dto = new CreateQuizDto
+        {
+            AlgorithmId = 7,
+            Title = "New Quiz",
+            Description = "Basics",
+            TimeLimitMins = 15,
+            PassScore = 80
+        };
+
+        var result = await BuildSut(quizRepository, userRepository, algorithmRepository)
+            .CreateQuizAsync(dto, "clerk_001");
+
+        result.QuizId.Should().Be(22);
+        result.CreatedBy.Should().Be(10);
+        result.IsActive.Should().BeTrue();
+        result.Title.Should().Be("New Quiz");
+    }
+
+    [Fact(DisplayName = "UpdateQuizAsync throws when the quiz cannot be found")]
+    public async Task UpdateQuizAsync_QuizMissing_ThrowsKeyNotFoundException()
+    {
+        var quizRepository = new Mock<IQuizRepository>();
+        quizRepository
+            .Setup(r => r.GetByIdAsync(99))
+            .ReturnsAsync((Quiz?)null);
+
+        var action = () => BuildSut(quizRepository).UpdateQuizAsync(99, new UpdateQuizDto { Title = "Updated", IsActive = true });
+
+        await action.Should()
+            .ThrowAsync<KeyNotFoundException>()
+            .WithMessage("Quiz with ID 99 was not found.");
+    }
+
+    [Fact(DisplayName = "UpdateQuizAsync updates quiz fields and returns the refreshed entity")]
+    public async Task UpdateQuizAsync_QuizExists_ReturnsUpdatedDto()
+    {
+        var existing = CreateQuiz(5);
+        var updated = CreateQuiz(5);
+        updated.Title = "Updated Quiz";
+        updated.PassScore = 85;
+        updated.IsActive = false;
+
+        var quizRepository = new Mock<IQuizRepository>();
+        quizRepository
+            .SetupSequence(r => r.GetByIdAsync(5))
+            .ReturnsAsync(existing)
+            .ReturnsAsync(updated);
+        quizRepository
+            .Setup(r => r.UpdateAsync(It.IsAny<Quiz>()))
+            .ReturnsAsync(true);
+
+        var result = await BuildSut(quizRepository).UpdateQuizAsync(5, new UpdateQuizDto
+        {
+            Title = "Updated Quiz",
+            Description = "Updated desc",
+            TimeLimitMins = 20,
+            PassScore = 85,
+            IsActive = false
+        });
+
+        result.Title.Should().Be("Updated Quiz");
+        result.PassScore.Should().Be(85);
+        result.IsActive.Should().BeFalse();
+    }
+
+    [Fact(DisplayName = "DeleteQuizAsync returns the repository result for soft deletion")]
+    public async Task DeleteQuizAsync_ReturnsRepositoryResult()
+    {
+        var quizRepository = new Mock<IQuizRepository>();
+        quizRepository
+            .Setup(r => r.DeleteAsync(7))
+            .ReturnsAsync(true);
+
+        var result = await BuildSut(quizRepository).DeleteQuizAsync(7);
+
+        result.Should().BeTrue();
+    }
+}

--- a/Testing/UnitTests/Services/XpServiceTests.cs
+++ b/Testing/UnitTests/Services/XpServiceTests.cs
@@ -1,0 +1,44 @@
+using backend.Services;
+using FluentAssertions;
+using Xunit;
+
+namespace backend.Tests.Services;
+
+public class XpServiceTests
+{
+    private readonly XpService _sut = new();
+
+    [Theory(DisplayName = "CalculateXP returns expected rewards for supported activity types and difficulties")]
+    [InlineData("quiz", "easy", 10)]
+    [InlineData("QUIZ", "MEDIUM", 20)]
+    [InlineData("coding", "hard", 200)]
+    [InlineData("CoDiNg", "Easy", 50)]
+    public void CalculateXP_SupportedInputs_ReturnsExpectedReward(string type, string difficulty, int expectedXp)
+    {
+        var result = _sut.CalculateXP(type, difficulty);
+
+        result.Should().Be(expectedXp);
+    }
+
+    [Fact(DisplayName = "CalculateXP throws for unsupported difficulty")]
+    public void CalculateXP_UnsupportedDifficulty_ThrowsArgumentException()
+    {
+        var action = () => _sut.CalculateXP("quiz", "expert");
+
+        action.Should()
+            .Throw<ArgumentException>()
+            .WithParameterName("difficulty")
+            .WithMessage("*expert*");
+    }
+
+    [Fact(DisplayName = "CalculateXP throws for unsupported activity type")]
+    public void CalculateXP_UnsupportedType_ThrowsArgumentException()
+    {
+        var action = () => _sut.CalculateXP("simulation", "easy");
+
+        action.Should()
+            .Throw<ArgumentException>()
+            .WithParameterName("type")
+            .WithMessage("*simulation*");
+    }
+}


### PR DESCRIPTION
- Implement tests for ActivityHeatmapService to verify daily activity retrieval.
- Add tests for ActivityService to ensure recent activity fetching works correctly.
- Create tests for AlgorithmService to validate algorithm retrieval and mapping.
- Introduce tests for BadgeService to check badge retrieval and awarding logic.
- Add tests for LeaderboardService to confirm leaderboard functionality.
- Implement tests for LevelingService to validate level calculations based on XP.
- Create tests for QuizAttemptService to ensure quiz submission logic is correct.
- Add tests for QuizService to verify CRUD operations for quizzes.
- Implement tests for XpService to validate XP calculation based on activity types and difficulties.