### PR TITLE
Sa 278 manually verify pdf output renders correctly header summary stats

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -401,10 +401,29 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          SUMMARY_PATH="Testing/PerformanceTests/results/summary.md"
+          RESULTS_JTL="Testing/PerformanceTests/results/results.jtl"
+
+          set +e
           python3 Testing/PerformanceTests/scripts/summarize_jmeter_results.py \
             --input Testing/PerformanceTests/results/results.jtl \
-            --output Testing/PerformanceTests/results/summary.md \
+            --output "${SUMMARY_PATH}" \
             --threshold-ms 5000
+          STATUS=$?
+          set -e
+
+          if [ -f "${SUMMARY_PATH}" ]; then
+            echo "Generated NFR summary:"
+            cat "${SUMMARY_PATH}"
+          else
+            echo "Summary file was not generated."
+          fi
+
+          if [ "${STATUS}" -ne 0 ]; then
+            echo "NFR-P03 evaluation failed. Showing first lines of JTL for diagnostics:"
+            head -n 20 "${RESULTS_JTL}" || true
+            exit "${STATUS}"
+          fi
 
       - name: Download admin report files for artifact
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,7 +372,6 @@ jobs:
           jmeter -n \
             -t Testing/PerformanceTests/staging-load-test.jmx \
             -l "${RESULTS_JTL}" \
-            -e -o Testing/PerformanceTests/results/dashboard \
             -JBASE_URL="${PERFORMANCE_BASE_URL}" \
             -JADMIN_JWT="${PERF_SERVICE_TOKEN}" \
             -JSTART_DATE="${PERFORMANCE_START_DATE}" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,8 @@ jobs:
       PERFORMANCE_RAMP_UP: '20'
       PERFORMANCE_LOOPS: '10'
       PERFORMANCE_RECORD_COUNT: '1000'
+      ENABLE_PERF_SERVICE_TOKEN_AUTH: 'true'
+      PERF_SERVICE_TOKEN: ${{ secrets.PERF_SERVICE_TOKEN }}
 
     steps:
       - name: Checkout code
@@ -355,62 +357,22 @@ jobs:
           echo "Inserted quiz attempts for perf dataset: ${INSERTED_COUNT}"
           test "${INSERTED_COUNT}" -ge "${PERFORMANCE_RECORD_COUNT}"
 
-      - name: Generate fresh admin JWT for performance tests
-        id: perf_admin_token
-        shell: bash
-        env:
-          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
-          PERF_ADMIN_USER_ID: ${{ vars.PERF_ADMIN_USER_ID }}
-          PERF_JWT_TEMPLATE: ${{ vars.PERF_JWT_TEMPLATE }}
-        run: |
-          set -euo pipefail
-
-          if [ -z "${CLERK_SECRET_KEY:-}" ] || [ -z "${PERF_ADMIN_USER_ID:-}" ] || [ -z "${PERF_JWT_TEMPLATE:-}" ]; then
-            echo "Missing one or more required values (CLERK_SECRET_KEY secret, PERF_ADMIN_USER_ID var, PERF_JWT_TEMPLATE var)."
-            echo "has_token=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          SESSION_ID=$(curl -fsS \
-            -H "Authorization: Bearer ${CLERK_SECRET_KEY}" \
-            "https://api.clerk.com/v1/sessions?user_id=${PERF_ADMIN_USER_ID}&status=active&limit=1" \
-            | python3 -c "import json,sys; data=json.load(sys.stdin); print(data[0]['id'] if isinstance(data, list) and data else '')")
-
-          if [ -z "${SESSION_ID}" ]; then
-            echo "No active Clerk session found for PERF_ADMIN_USER_ID=${PERF_ADMIN_USER_ID}."
-            echo "Sign in once with that user to create an active session, then rerun."
-            echo "has_token=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          PERFORMANCE_ADMIN_JWT=$(curl -fsS -X POST \
-            -H "Authorization: Bearer ${CLERK_SECRET_KEY}" \
-            "https://api.clerk.com/v1/sessions/${SESSION_ID}/tokens/${PERF_JWT_TEMPLATE}" \
-            | python3 -c "import json,sys; print(json.load(sys.stdin).get('jwt',''))")
-
-          if [ -z "${PERFORMANCE_ADMIN_JWT}" ]; then
-            echo "Failed to generate session token from Clerk."
-            echo "has_token=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          echo "::add-mask::${PERFORMANCE_ADMIN_JWT}"
-          echo "PERFORMANCE_ADMIN_JWT=${PERFORMANCE_ADMIN_JWT}" >> "$GITHUB_ENV"
-          echo "has_token=true" >> "$GITHUB_OUTPUT"
-
       - name: Run JMeter load test (admin endpoints)
-        if: ${{ steps.perf_admin_token.outputs.has_token == 'true' }}
         shell: bash
         run: |
           set -euo pipefail
           mkdir -p Testing/PerformanceTests/results
+          if [ -z "${PERF_SERVICE_TOKEN:-}" ]; then
+            echo "Missing required secret: PERF_SERVICE_TOKEN"
+            exit 1
+          fi
 
           jmeter -n \
             -t Testing/PerformanceTests/staging-load-test.jmx \
             -l Testing/PerformanceTests/results/results.jtl \
             -e -o Testing/PerformanceTests/results/dashboard \
             -JBASE_URL="${PERFORMANCE_BASE_URL}" \
-            -JADMIN_JWT="${PERFORMANCE_ADMIN_JWT}" \
+            -JADMIN_JWT="${PERF_SERVICE_TOKEN}" \
             -JSTART_DATE="${PERFORMANCE_START_DATE}" \
             -JEND_DATE="${PERFORMANCE_END_DATE}" \
             -JUSERS="${PERFORMANCE_USERS}" \
@@ -418,7 +380,6 @@ jobs:
             -JLOOPS="${PERFORMANCE_LOOPS}"
 
       - name: Evaluate NFR-P03 from JMeter results
-        if: ${{ steps.perf_admin_token.outputs.has_token == 'true' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -428,27 +389,20 @@ jobs:
             --threshold-ms 5000
 
       - name: Download admin report files for artifact
-        if: ${{ steps.perf_admin_token.outputs.has_token == 'true' }}
         shell: bash
         run: |
           set -euo pipefail
           mkdir -p Testing/PerformanceTests/results/admin-reports
 
           curl -fS \
-            -H "Authorization: Bearer ${PERFORMANCE_ADMIN_JWT}" \
+            -H "Authorization: Bearer ${PERF_SERVICE_TOKEN}" \
             "${PERFORMANCE_BASE_URL}/api/admin/reports?format=csv&startDate=${PERFORMANCE_START_DATE}&endDate=${PERFORMANCE_END_DATE}" \
             -o Testing/PerformanceTests/results/admin-reports/admin-report.csv
 
           curl -fS \
-            -H "Authorization: Bearer ${PERFORMANCE_ADMIN_JWT}" \
+            -H "Authorization: Bearer ${PERF_SERVICE_TOKEN}" \
             "${PERFORMANCE_BASE_URL}/api/admin/reports?format=pdf&startDate=${PERFORMANCE_START_DATE}&endDate=${PERFORMANCE_END_DATE}" \
             -o Testing/PerformanceTests/results/admin-reports/admin-report.pdf
-
-      - name: Skip admin performance tests when runtime JWT is unavailable
-        if: ${{ steps.perf_admin_token.outputs.has_token != 'true' }}
-        shell: bash
-        run: |
-          echo "Skipping admin performance test execution because no runtime admin JWT could be generated."
 
       - name: Upload JMeter dashboard and NFR summary
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -362,6 +362,8 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p Testing/PerformanceTests/results
+          RESULTS_JTL="Testing/PerformanceTests/results/results.jtl"
+          JMETER_LOG="Testing/PerformanceTests/results/jmeter.log"
           if [ -z "${PERF_SERVICE_TOKEN:-}" ]; then
             echo "Missing required secret: PERF_SERVICE_TOKEN"
             exit 1
@@ -369,7 +371,7 @@ jobs:
 
           jmeter -n \
             -t Testing/PerformanceTests/staging-load-test.jmx \
-            -l Testing/PerformanceTests/results/results.jtl \
+            -l "${RESULTS_JTL}" \
             -e -o Testing/PerformanceTests/results/dashboard \
             -JBASE_URL="${PERFORMANCE_BASE_URL}" \
             -JADMIN_JWT="${PERF_SERVICE_TOKEN}" \
@@ -377,7 +379,17 @@ jobs:
             -JEND_DATE="${PERFORMANCE_END_DATE}" \
             -JUSERS="${PERFORMANCE_USERS}" \
             -JRAMP_UP="${PERFORMANCE_RAMP_UP}" \
-            -JLOOPS="${PERFORMANCE_LOOPS}"
+            -JLOOPS="${PERFORMANCE_LOOPS}" \
+            -j "${JMETER_LOG}"
+
+          if [ ! -f "${RESULTS_JTL}" ]; then
+            echo "JMeter completed but no results file was produced at ${RESULTS_JTL}"
+            echo "JMeter log:"
+            cat "${JMETER_LOG}" || true
+            echo "Backend log:"
+            cat /tmp/backend-perf.log || true
+            exit 1
+          fi
 
       - name: Evaluate NFR-P03 from JMeter results
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,7 +225,14 @@ jobs:
           if-no-files-found: warn
 
       - name: Install JMeter
-        run: sudo apt-get update && sudo apt-get install -y jmeter
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y default-jdk wget
+          wget -q https://archive.apache.org/dist/jmeter/binaries/apache-jmeter-5.6.3.tgz
+          tar -xzf apache-jmeter-5.6.3.tgz
+          echo "$PWD/apache-jmeter-5.6.3/bin" >> "$GITHUB_PATH"
 
       - name: Start backend API for performance tests
         shell: bash

--- a/Program.cs
+++ b/Program.cs
@@ -7,8 +7,10 @@ using backend.Services.Simulations;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.AspNetCore.Authentication;
 using Serilog;
 using Serilog.Sinks.ApplicationInsights.TelemetryConverters;
+using backend.Security;
 
 // ── Serilog Bootstrap ─────────────────────────────────────────────
 Log.Logger = new LoggerConfiguration()
@@ -173,12 +175,44 @@ if (string.IsNullOrWhiteSpace(clerkAuthority))
 var clerkAudience = Environment.GetEnvironmentVariable("CLERK_AUDIENCE")
     ?? builder.Configuration["Clerk:Audience"];  // optional — null disables audience check
 
+var perfServiceToken = Environment.GetEnvironmentVariable("PERF_SERVICE_TOKEN")
+    ?? builder.Configuration["Perf:ServiceToken"];
+var enablePerfServiceTokenAuth =
+    string.Equals(Environment.GetEnvironmentVariable("ENABLE_PERF_SERVICE_TOKEN_AUTH"), "true", StringComparison.OrdinalIgnoreCase)
+    || builder.Configuration.GetValue<bool>("Perf:EnableServiceTokenAuth");
+
+builder.Services.Configure<PerfServiceTokenOptions>(options =>
+{
+    options.Enabled = enablePerfServiceTokenAuth;
+    options.Token = perfServiceToken;
+});
+
 builder.Services
     .AddAuthentication(options =>
     {
-        options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
-        options.DefaultChallengeScheme    = JwtBearerDefaults.AuthenticationScheme;
+        options.DefaultAuthenticateScheme = "SmartAuth";
+        options.DefaultChallengeScheme    = "SmartAuth";
     })
+    .AddPolicyScheme("SmartAuth", "JWT or Performance service token", options =>
+    {
+        options.ForwardDefaultSelector = context =>
+        {
+            var authorization = context.Request.Headers.Authorization.ToString();
+            if (enablePerfServiceTokenAuth
+                && !string.IsNullOrWhiteSpace(perfServiceToken)
+                && authorization.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+            {
+                var incomingToken = authorization["Bearer ".Length..].Trim();
+                if (incomingToken == perfServiceToken)
+                    return PerfServiceTokenAuthenticationHandler.SchemeName;
+            }
+
+            return JwtBearerDefaults.AuthenticationScheme;
+        };
+    })
+    .AddScheme<AuthenticationSchemeOptions, PerfServiceTokenAuthenticationHandler>(
+        PerfServiceTokenAuthenticationHandler.SchemeName,
+        _ => { })
     .AddJwtBearer(options =>
     {
         // Clerk publishes its JWKS at {Authority}/.well-known/jwks.json

--- a/Repositories/ReportRepository.cs
+++ b/Repositories/ReportRepository.cs
@@ -31,7 +31,7 @@ public class ReportRepository : IReportRepository
                 COALESCE(SUM(qa.xp_earned), 0) AS total_xp,
                 COUNT(DISTINCT qa.quiz_id) AS algorithms_attempted
             FROM quiz_attempts qa
-            JOIN users u ON qa.user_id = u.id
+            JOIN Users u ON qa.user_id = u.id
             WHERE COALESCE(qa.completed_at, qa.submitted_at) BETWEEN @StartDate AND @EndDate
             GROUP BY u.id, u.email
             ORDER BY u.email;";

--- a/Security/PerfServiceTokenAuthenticationHandler.cs
+++ b/Security/PerfServiceTokenAuthenticationHandler.cs
@@ -1,0 +1,68 @@
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Options;
+
+namespace backend.Security;
+
+public sealed class PerfServiceTokenOptions
+{
+    public bool Enabled { get; set; }
+    public string? Token { get; set; }
+}
+
+public sealed class PerfServiceTokenAuthenticationHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+{
+    public const string SchemeName = "PerfServiceToken";
+    private readonly IOptions<PerfServiceTokenOptions> _options;
+
+    public PerfServiceTokenAuthenticationHandler(
+        IOptionsMonitor<AuthenticationSchemeOptions> schemeOptions,
+        ILoggerFactory logger,
+        UrlEncoder encoder,
+        ISystemClock clock,
+        IOptions<PerfServiceTokenOptions> options)
+        : base(schemeOptions, logger, encoder, clock)
+    {
+        _options = options;
+    }
+
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        var options = _options.Value;
+        if (!options.Enabled || string.IsNullOrWhiteSpace(options.Token))
+            return Task.FromResult(AuthenticateResult.NoResult());
+
+        if (!Request.Headers.TryGetValue("Authorization", out var authHeaders))
+            return Task.FromResult(AuthenticateResult.NoResult());
+
+        var authorization = authHeaders.ToString();
+        if (!authorization.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+            return Task.FromResult(AuthenticateResult.NoResult());
+
+        var incomingToken = authorization["Bearer ".Length..].Trim();
+        if (string.IsNullOrEmpty(incomingToken))
+            return Task.FromResult(AuthenticateResult.NoResult());
+
+        var incomingBytes = Encoding.UTF8.GetBytes(incomingToken);
+        var expectedBytes = Encoding.UTF8.GetBytes(options.Token);
+
+        if (!CryptographicOperations.FixedTimeEquals(incomingBytes, expectedBytes))
+            return Task.FromResult(AuthenticateResult.NoResult());
+
+        var claims = new[]
+        {
+            new Claim("sub", "perf-service-token"),
+            new Claim("role", "Admin"),
+            new Claim(ClaimTypes.NameIdentifier, "perf-service-token"),
+            new Claim(ClaimTypes.Role, "Admin"),
+        };
+
+        var identity = new ClaimsIdentity(claims, SchemeName);
+        var principal = new ClaimsPrincipal(identity);
+        var ticket = new AuthenticationTicket(principal, SchemeName);
+        return Task.FromResult(AuthenticateResult.Success(ticket));
+    }
+}

--- a/Services/ReportService.cs
+++ b/Services/ReportService.cs
@@ -27,19 +27,19 @@ public class ReportService : IReportService
 
         try
         {
-            var summaryTask = _reportRepository.GetSummaryStatisticsAsync(startDate, endDate);
-            var perStudentTask = _reportRepository.GetPerStudentReportAsync(startDate, endDate);
-            var perAlgorithmTask = _reportRepository.GetPerAlgorithmReportAsync(startDate, endDate);
-            var perQuizTask = _reportRepository.GetPerQuizReportAsync(startDate, endDate);
-
-            await Task.WhenAll(summaryTask, perStudentTask, perAlgorithmTask, perQuizTask);
+            // Run sequentially to avoid opening 4 concurrent DB connections per request.
+            // Under load tests, parallel fan-out here can exhaust MySQL connection limits.
+            var summary = await _reportRepository.GetSummaryStatisticsAsync(startDate, endDate);
+            var perStudent = await _reportRepository.GetPerStudentReportAsync(startDate, endDate);
+            var perAlgorithm = await _reportRepository.GetPerAlgorithmReportAsync(startDate, endDate);
+            var perQuiz = await _reportRepository.GetPerQuizReportAsync(startDate, endDate);
 
             return new AdminReportBundleDto
             {
-                Summary = await summaryTask,
-                PerStudent = await perStudentTask,
-                PerAlgorithm = await perAlgorithmTask,
-                PerQuiz = await perQuizTask
+                Summary = summary,
+                PerStudent = perStudent,
+                PerAlgorithm = perAlgorithm,
+                PerQuiz = perQuiz
             };
         }
         catch (Exception ex)

--- a/Testing/PerformanceTests/staging-load-test.jmx
+++ b/Testing/PerformanceTests/staging-load-test.jmx
@@ -68,7 +68,7 @@
           <stringProp name="HTTPSampler.domain"/>
           <stringProp name="HTTPSampler.port"/>
           <stringProp name="HTTPSampler.protocol"/>
-          <stringProp name="HTTPSampler.path">${__P(BASE_URL,http://localhost:5181)}/api/admin/reports</stringProp>
+          <stringProp name="HTTPSampler.path">${__P(BASE_URL,http://localhost:5181)}/api/admin/reports?format=csv&amp;startDate=${__P(START_DATE,2026-04-01)}&amp;endDate=${__P(END_DATE,2026-04-30)}</stringProp>
           <stringProp name="HTTPSampler.method">GET</stringProp>
           <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
           <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
@@ -119,7 +119,7 @@
           <stringProp name="HTTPSampler.domain"/>
           <stringProp name="HTTPSampler.port"/>
           <stringProp name="HTTPSampler.protocol"/>
-          <stringProp name="HTTPSampler.path">${__P(BASE_URL,http://localhost:5181)}/api/admin/reports</stringProp>
+          <stringProp name="HTTPSampler.path">${__P(BASE_URL,http://localhost:5181)}/api/admin/reports?format=pdf&amp;startDate=${__P(START_DATE,2026-04-01)}&amp;endDate=${__P(END_DATE,2026-04-30)}</stringProp>
           <stringProp name="HTTPSampler.method">GET</stringProp>
           <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
           <boolProp name="HTTPSampler.auto_redirects">false</boolProp>


### PR DESCRIPTION
changed both backend auth and CI to use a custom service token (no Clerk calls for perf auth), and generated a token
What changed:

- Added PerfServiceToken auth handler that authenticates Authorization: Bearer <PERF_SERVICE_TOKEN> as Admin.
- Added smart auth routing (SmartAuth) so regular Clerk JWT still works, and perf token works when enabled.
- CI now:
- sets ENABLE_PERF_SERVICE_TOKEN_AUTH: 'true'
- reads PERF_SERVICE_TOKEN from GitHub secret
- uses it for JMeter (-JADMIN_JWT) and admin report downloads
- removed runtime Clerk token generation steps entirely.